### PR TITLE
v0.6.0: library-backed legacy migration API and UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project are documented here.
 
+## [0.6.0] - 2026-08-20
+
+### Added
+
+- `memory.legacyRecords()` exposes metadata-only legacy-record discovery to
+  the host and settings UI.
+- `memory.migrateLegacy({ dryRun })` moves the existing CLI migration logic
+  into the library and applies front matter through the normal staged,
+  host-owned recovery/apply transaction.
+- `dsh-memory-migrate --dry-run|--apply` now delegates to the library API.
+- Settings UI now shows pending legacy paths and deterministic generated ids,
+  and offers an explicit migration action.
+
+### Safety
+
+- Dry-run does not write the live repository, journal, watermark, or Git.
+- Migration preserves legacy record bodies and stores metadata only in the
+  journal; no transcript, prompt, credential, or memory body is exposed.
+- Applying migration is idempotent and uses the existing operation lock.
+
 ## [0.5.0] - 2026-08-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -125,9 +125,26 @@ v0.5 adds operational tooling around the memory store:
   unsupported) and the integration tool defaults.
 - The release checklist now verifies the backup round-trip before release.
 
+## v0.6: library-backed legacy migration and UI visibility
+
+v0.6 moves legacy-record inspection and migration into the host library so the
+CLI and settings UI use the same safe transaction path:
+
+- `memory.legacyRecords()` returns metadata-only entries for legacy Markdown
+  files (path, deterministic id, generated front matter, dates, and size).
+- `memory.migrateLegacy({ dryRun: true })` is read-only; applying with
+  `{ dryRun: false }` stages the changes, validates them, and performs a
+  host-owned recovery/apply transaction. It only adds deterministic front
+  matter and preserves each record body.
+- `dsh-memory-migrate --dry-run` and `--apply` delegate to those library APIs.
+  The journal records operation metadata only; it never contains memory body,
+  transcript, prompt, or credential content.
+- The settings UI shows pending legacy paths and generated ids and offers an
+  explicit migration action. It does not expose the filesystem root or run Git.
+
 ## Compatibility
 
-`v0.5.0` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
+`v0.6.0` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
 tested and locally integrated with a consistently pinned `0.1.0-rc.7` graph:
 
 | Component | Supported version |
@@ -153,14 +170,14 @@ Clone the repository and install its reproducible development/runtime dependenci
 ```zsh
 git clone https://github.com/seriousz158/dsh-memory.git
 cd dsh-memory
-# Use the pinned runtime that this v0.5.0 integration was tested with.
+# Use the pinned runtime that this v0.6.0 integration was tested with.
 npm install --global @deepseek-ai/dsh@0.1.0-rc.7
 dsh --version
 npm ci --ignore-scripts
 ```
 
 This is a source-and-GitHub-Release project. Both workspace packages are
-intentionally marked private, so `v0.5.0` cannot be published to npm by
+intentionally marked private, so `v0.6.0` cannot be published to npm by
 accident.
 
 Install the two local packages into your DSH profile. The installer defaults to
@@ -228,6 +245,8 @@ The local UI talks only to the fixed `memory` remote service:
 memory.getSettings()
 memory.setEnabled({ enabled: boolean })
 memory.status()
+memory.legacyRecords()
+memory.migrateLegacy({ dryRun: boolean })
 memory.clear({ confirmation: "DELETE_MEMORY" })
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -139,6 +139,67 @@ payload records (handbook/, rollouts/, archive/) without front matter;
 is true when at least one legacy record exists. `lastRun` is null before the
 first journaled run and otherwise reflects `.sync/last-run.json`.
 
+### `memory.legacyRecords()` (v0.6)
+
+Returns metadata-only descriptions of legacy Markdown records under
+`handbook/`, `rollouts/`, and `archive/`. Files that already have valid front
+matter are not returned. The response never includes the record body:
+
+```json
+{
+  "ok": true,
+  "value": {
+    "count": 1,
+    "pendingMigration": true,
+    "records": [
+      {
+        "path": "handbook/old-note.md",
+        "id": "legacy-4f2b7c1a9e0d3c55",
+        "frontMatter": "---\nschema_version: 1\nid: legacy-4f2b7c1a9e0d3c55\ncreated_at: 2026-08-20\nupdated_at: 2026-08-20\n---\n\n",
+        "createdAt": "2026-08-20",
+        "updatedAt": "2026-08-20",
+        "bytes": 128
+      }
+    ]
+  }
+}
+```
+
+Failures use `repo-unavailable`, `unsafe-layout`, or a migration-specific
+filesystem error code.
+
+### `memory.migrateLegacy({ dryRun })` (v0.6)
+
+`dryRun` is required and must be a boolean. `true` returns the pending records
+and planned paths without changing the worktree, journal, watermark, or Git:
+
+```json
+{
+  "ok": true,
+  "value": {
+    "dryRun": true,
+    "status": "pending",
+    "legacyCount": 1,
+    "migratedCount": 0,
+    "changedPaths": ["handbook/old-note.md"],
+    "recoveryCommit": null,
+    "applyCommit": null,
+    "journalCommit": null
+  }
+}
+```
+
+`{ "dryRun": false }` applies deterministic front matter through the same
+staging, validation, operation-lock, recovery/apply-commit, and metadata-only
+journal path used by host-owned sync. The original Markdown body is preserved.
+Applying again returns `status: "no_change"` with no new payload commit.
+
+Failures use `migration-invalid-request`, `repo-unavailable`, `unsafe-layout`,
+`operation-in-progress`, `interrupted-run`, or a stable `migration-*` error
+code. If an older process left an active run, the host journals it as
+`status: "interrupted"` and stops; the operator must inspect `health()` and
+recover the repository explicitly before applying another migration.
+
 ### `memory.status()` (v0.3)
 
 The response adds a pending-preview field:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -81,7 +81,7 @@ used during installation.
 
 The sync command does not install DSH. It requires a `dsh` executable on `PATH`, or a deliberately configured `DSH_BIN`. It performs no work while `memory.enabled` is false.
 
-The v0.5.0 host and UI packages still declare the runtime peer range
+The v0.6.0 host and UI packages still declare the runtime peer range
 `@deepseek-ai/dsh@^0.1.0-rc.6`, so DSH `rc.6` remains peer-compatible. The
 repository's reproducible clean-room and local integration baseline is
 `0.1.0-rc.7`, because the registry's `rc.6` transitive peer graph is not

--- a/integrations/dsh/dsh-memory-migrate
+++ b/integrations/dsh/dsh-memory-migrate
@@ -2,109 +2,13 @@
 /**
  * dsh-memory-migrate: progressive front matter migration for legacy records.
  *
- *   dsh-memory-migrate --dry-run   report which legacy files would change
- *   dsh-memory-migrate --apply     add front matter to legacy records
+ * The CLI is a thin presentation wrapper around the host-owned library API.
+ * It never exposes record bodies and never calls a model.
  *
- * Migration never calls a model, never infers type/status/confidence, and
- * never edits the record body. It only prepends a stable front matter block
- * with schema_version, a deterministic legacy id, and the file's mtime date.
- * --apply builds a recovery/apply commit pair and records the run in the
- * journal. Re-running is idempotent.
+ *   dsh-memory-migrate --dry-run   report which legacy files would change
+ *   dsh-memory-migrate --apply     add front matter transactionally
  */
-import { execFile as execFileCallback } from "node:child_process";
-import { promisify } from "node:util";
-import { createHash } from "node:crypto";
-import { readdir, readFile, stat, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join, relative, resolve } from "node:path";
-import { parseFrontMatter } from "../../packages/dsh-memory/lib/memory-metadata.js";
-import { isPayloadPath } from "../../packages/dsh-memory/lib/memory-tree.js";
-
-const execFile = promisify(execFileCallback);
-const DSH_HOME = resolve(process.env.DSH_HOME || join(homedir(), ".dsh"));
-const MEMORY_ROOT = resolve(process.env.DSH_MEMORY_ROOT || join(DSH_HOME, "storages", "memory"));
-
-async function git(args) {
-  const { stdout } = await execFile("/usr/bin/git", ["-C", MEMORY_ROOT, ...args], { encoding: "utf8" });
-  return stdout.trim();
-}
-
-async function walk(directory) {
-  const files = [];
-  const entries = await readdir(directory, { withFileTypes: true });
-  for (const entry of entries) {
-    const full = join(directory, entry.name);
-    if (entry.isDirectory()) files.push(...await walk(full));
-    else if (entry.isFile()) files.push(full);
-  }
-  return files;
-}
-
-async function legacyRecords() {
-  const records = [];
-  const roots = ["handbook", "rollouts", "archive"].map((name) => join(MEMORY_ROOT, name));
-  for (const root of roots) {
-    for (const file of await walk(root)) {
-      if (!file.endsWith(".md")) continue;
-      const rel = relative(MEMORY_ROOT, file);
-      if (!isPayloadPath(rel)) continue;
-      const content = await readFile(file, "utf8");
-      if (parseFrontMatter(content, rel) !== null) continue; // already structured
-      records.push({ file, rel, content });
-    }
-  }
-  return records.sort((a, b) => a.rel.localeCompare(b.rel));
-}
-
-function legacyId(rel) {
-  const digest = createHash("sha256").update(rel).digest("hex").slice(0, 16);
-  return `legacy-${digest}`;
-}
-
-function migratedContent(record, mtime) {
-  const date = mtime.toISOString().slice(0, 10);
-  // Migration only adds stable fields: schema_version, a deterministic id,
-  // and the file mtime date. It never infers type/status/confidence.
-  const block = [
-    "---",
-    "schema_version: 1",
-    `id: ${legacyId(record.rel)}`,
-    `created_at: ${date}`,
-    `updated_at: ${date}`,
-    "---",
-  ].join("\n");
-  return block + "\n" + record.content;
-}
-
-async function journal(runId, status, changedPaths, recoveryCommit, applyCommit, errorCode) {
-  const now = new Date().toISOString();
-  const record = {
-    schema_version: 1,
-    run_id: runId,
-    operation: "migrate",
-    status,
-    started_at: now,
-    finished_at: now,
-    candidate_sessions: 0,
-    processed_sessions: changedPaths.length,
-    skipped_sessions: 0,
-    changed_paths: changedPaths,
-    recovery_commit: recoveryCommit ?? null,
-    apply_commit: applyCommit ?? null,
-    error_code: errorCode ?? null,
-  };
-  const runsDir = join(MEMORY_ROOT, ".sync", "runs");
-  const { mkdir } = await import("node:fs/promises");
-  await mkdir(runsDir, { recursive: true });
-  await writeFile(join(runsDir, `${runId}.json`), JSON.stringify(record, null, 2) + "\n", { mode: 0o600 });
-  const last = { ...record };
-  delete last.candidate_sessions;
-  delete last.processed_sessions;
-  delete last.skipped_sessions;
-  await writeFile(join(MEMORY_ROOT, ".sync", "last-run.json"), JSON.stringify(last, null, 2) + "\n", { mode: 0o600 });
-  await git(["add", "--", ".sync"]);
-  await git(["commit", "-m", `DPSK memory journal: ${runId}`, "--", ".sync"]);
-}
+import { MemoryRepository } from "../../packages/dsh-memory/lib/index.js";
 
 const dryRun = process.argv.includes("--dry-run");
 const apply = process.argv.includes("--apply");
@@ -113,57 +17,25 @@ if (dryRun === apply) {
   process.exit(2);
 }
 
-let records;
-try {
-  records = await legacyRecords();
-} catch (error) {
-  console.error(`dsh-memory-migrate: cannot read memory repository at ${MEMORY_ROOT}: ${error.message}`);
+const result = await new MemoryRepository().migrateLegacy({ dryRun });
+if (!result.ok) {
+  console.error(`dsh-memory-migrate: failed (${result.error.code})`);
   process.exit(1);
 }
 
-if (dryRun) {
-  if (records.length === 0) {
-    console.log("dsh-memory-migrate: no legacy records; nothing to migrate.");
-    process.exit(0);
-  }
-  console.log(`dsh-memory-migrate: ${records.length} legacy record(s) would be migrated:`);
-  for (const record of records) console.log(`  ${record.rel}`);
-  process.exit(0);
-}
-
-// --apply
-if (records.length === 0) {
+const value = result.value;
+if (value.status === "no_change") {
   console.log("dsh-memory-migrate: no legacy records; nothing to migrate.");
   process.exit(0);
 }
 
-const runId = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z") + "-migrate";
-const head = await git(["rev-parse", "HEAD"]);
-const changedPaths = [];
-
-try {
-  // 1. Migration recovery commit: the current HEAD tree is the recovery point
-  // because migration only prepends front matter to tracked files.
-  const recoveryCommit = head;
-
-  // 2. Add front matter to each legacy record, preserving the body.
-  for (const record of records) {
-    const mtime = await stat(record.file);
-    const updated = migratedContent(record, mtime.mtime);
-    await writeFile(record.file, updated, { mode: 0o600 });
-    changedPaths.push(record.rel);
-  }
-
-  // 3. Apply commit with the migrated payload.
-  await git(["add", "--", ...changedPaths]);
-  const applyCommit = await git(["commit", "-m", `DPSK memory migrate: ${runId}`]);
-  await journal(runId, "applied", changedPaths, recoveryCommit, applyCommit, null);
-  console.log(`dsh-memory-migrate: migrated ${changedPaths.length} record(s) (recovery ${recoveryCommit.slice(0, 8)}, apply ${applyCommit.slice(0, 8)}).`);
-} catch (error) {
-  try {
-    await git(["reset", "--mixed", head]);
-  } catch {}
-  await journal(runId, "failed", changedPaths, head, null, "migrate-failed");
-  console.error(`dsh-memory-migrate: migration failed: ${error.message}`);
-  process.exit(1);
+if (dryRun) {
+  console.log(`dsh-memory-migrate: ${value.legacyCount} legacy record(s) would be migrated:`);
+  for (const record of value.records) console.log(`  ${record.path} -> ${record.id}`);
+  process.exit(0);
 }
+
+console.log(
+  `dsh-memory-migrate: migrated ${value.migratedCount} record(s)`
+  + ` (recovery ${String(value.recoveryCommit).slice(0, 8)}, apply ${String(value.applyCommit).slice(0, 8)}).`,
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-memory-workspace",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-memory-workspace",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "workspaces": [
         "packages/dsh-memory",
         "packages/dsh-memory-ui"
@@ -1131,7 +1131,7 @@
       }
     },
     "packages/dsh-memory": {
-      "version": "0.1.0",
+      "version": "0.6.0",
       "license": "MIT",
       "engines": {
         "node": ">=22"
@@ -1143,7 +1143,7 @@
       }
     },
     "packages/dsh-memory-ui": {
-      "version": "0.1.0",
+      "version": "0.6.0",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory-workspace",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "Portable DSH long-term memory host and settings UI",
   "workspaces": [

--- a/packages/dsh-memory-ui/lib/client.js
+++ b/packages/dsh-memory-ui/lib/client.js
@@ -13,12 +13,15 @@ window.__ModuleLoader__.load({
       return transport.ok ? result(transport.value) : transport;
     };
     const enabledRequest = (value) => { if (!value || typeof value !== "object" || typeof value.enabled !== "boolean") throw new Error("invalid memory setting request"); return value; };
+    const migrationRequest = (value) => { if (!value || typeof value !== "object" || typeof value.dryRun !== "boolean") throw new Error("invalid migration request"); return value; };
     const rollbackRequest = (value) => { if (!value || value.confirmation !== "ROLLBACK_MEMORY" || typeof value.runId !== "string" || value.runId.length === 0) throw new Error("invalid rollback request"); return value; };
     const remote = { package: "dsh-memory", descriptors: [
       { id: "dsh-memory#memory/getSettings", service: "memory", namespace: "memory", method: "getSettings", invocation: { kind: "direct" }, parameters: [], result: strict(result) },
       { id: "dsh-memory#memory/setEnabled", service: "memory", namespace: "memory", method: "setEnabled", invocation: { kind: "direct" }, parameters: [{ name: "request", wire: "request", source: "json", codec: strict(enabledRequest) }], result: strict(result) },
       { id: "dsh-memory#memory/status", service: "memory", namespace: "memory", method: "status", invocation: { kind: "direct" }, parameters: [], result: strict(result) },
       { id: "dsh-memory#memory/health", service: "memory", namespace: "memory", method: "health", invocation: { kind: "direct" }, parameters: [], result: strict(result) },
+      { id: "dsh-memory#memory/legacyRecords", service: "memory", namespace: "memory", method: "legacyRecords", invocation: { kind: "direct" }, parameters: [], result: strict(result) },
+      { id: "dsh-memory#memory/migrateLegacy", service: "memory", namespace: "memory", method: "migrateLegacy", invocation: { kind: "direct" }, parameters: [{ name: "request", wire: "request", source: "json", codec: strict(migrationRequest) }], result: strict(result) },
       { id: "dsh-memory#memory/clear", service: "memory", namespace: "memory", method: "clear", invocation: { kind: "direct" }, parameters: [{ name: "request", wire: "request", source: "json", codec: strict((value) => { if (!value || value.confirmation !== "DELETE_MEMORY") throw new Error("invalid clear request"); return value; }) }], result: strict(result) },
       { id: "dsh-memory#memory/runs", service: "memory", namespace: "memory", method: "runs", invocation: { kind: "direct" }, parameters: [{ name: "request", wire: "request", source: "json", codec: strict((value) => { if (value !== undefined && value !== null && typeof value !== "object") throw new Error("invalid runs request"); return value; }) }], result: strict(result) },
       { id: "dsh-memory#memory/rollback", service: "memory", namespace: "memory", method: "rollback", invocation: { kind: "direct" }, parameters: [{ name: "request", wire: "request", source: "json", codec: strict(rollbackRequest) }], result: strict(result) },
@@ -84,6 +87,10 @@ window.__ModuleLoader__.load({
             const [repositoryRevision, setRepositoryRevision] = react.useState(0);
             const [rollbackState, setRollbackState] = react.useState(null);
             const [rollbackBusy, setRollbackBusy] = react.useState(false);
+            const [legacyList, setLegacyList] = react.useState(null);
+            const [legacyError, setLegacyError] = react.useState(null);
+            const [migrationBusy, setMigrationBusy] = react.useState(false);
+            const [migrationAction, setMigrationAction] = react.useState(null);
             react.useEffect(() => {
               let disposed = false;
               const load = async () => {
@@ -92,6 +99,22 @@ window.__ModuleLoader__.load({
                   if (!disposed) setRepository(answer.ok ? { value: answer.value } : { error: answer.error.code });
                 } catch {
                   if (!disposed) setRepository({ error: "repo-unavailable" });
+                }
+              };
+              void load();
+              return () => { disposed = true; };
+            }, [repositoryRevision]);
+            react.useEffect(() => {
+              let disposed = false;
+              const load = async () => {
+                try {
+                  const answer = operationResult(await memory.legacyRecords());
+                  if (!disposed) {
+                    setLegacyList(answer.ok ? answer.value.records : null);
+                    setLegacyError(answer.ok ? null : answer.error.code);
+                  }
+                } catch {
+                  if (!disposed) { setLegacyList(null); setLegacyError("legacy-unavailable"); }
                 }
               };
               void load();
@@ -157,6 +180,21 @@ window.__ModuleLoader__.load({
                 setPreviewBusy(false);
               }
             };
+            const migrateLegacy = async () => {
+              if (!legacyList || legacyList.length === 0) return;
+              if (!window.confirm(`迁移 ${legacyList.length} 个 legacy 记录？只会补充 front matter，不会修改记忆正文。`)) return;
+              setMigrationBusy(true); setMigrationAction(null);
+              try {
+                const answer = operationResult(await memory.migrateLegacy({ dryRun: false }));
+                if (!answer.ok) return setMigrationAction({ error: answer.error.code });
+                setMigrationAction({ success: answer.value.migratedCount ? `已迁移 ${answer.value.migratedCount} 个 legacy 记录` : "没有需要迁移的 legacy 记录" });
+                setRepositoryRevision((revision) => revision + 1);
+              } catch {
+                setMigrationAction({ error: "legacy-migration-failed" });
+              } finally {
+                setMigrationBusy(false);
+              }
+            };
             const clear = async () => {
               if (stage < 2) return setStage(stage + 1);
               setBusy(true); setState(null);
@@ -187,6 +225,13 @@ window.__ModuleLoader__.load({
                 stage === 2 && jsx.jsxs(jsx.Fragment, { children: [jsx.jsx("input", { className: "dshmu_input", "aria-label": "删除记忆确认", value: phrase, onChange: (event) => setPhrase(event.target.value), placeholder: "输入 删除记忆 以确认" }), jsx.jsx("span", { className: "dshmu_status dshmu_error", children: "请输入“删除记忆”后进行最终确认。" })] }),
                 jsx.jsx("button", { type: "button", className: "dshmu_button", disabled: !available || busy || (stage === 2 && phrase !== "删除记忆"), onClick: clear, children: busy ? "正在清空…" : stage === 0 ? "删除记忆" : stage === 1 ? "继续" : "最终确认删除" }),
                 state && jsx.jsx("span", { className: state.error ? "dshmu_status dshmu_error" : "dshmu_status", children: state.error ? `清空失败：${state.error}` : state.success }),
+              ] }),
+              jsx.jsxs("div", { className: "dshmu_clear", children: [
+                jsx.jsx("span", { className: "dshmu_title", children: "Legacy 记录" }),
+                jsx.jsx("span", { className: legacyError ? "dshmu_status dshmu_error" : "dshmu_status", children: legacyList === null ? legacyError ? `legacy 记录不可用：${legacyError}` : "正在读取 legacy 记录…" : legacyList.length === 0 ? "没有待迁移的 legacy 记录" : `待迁移 ${legacyList.length} 个 legacy 记录` }),
+                legacyList && legacyList.map((record) => jsx.jsx("span", { className: "dshmu_status", children: `${record.path} → ${record.id}` }, record.path)),
+                jsx.jsx("button", { type: "button", className: "dshmu_button", disabled: !available || migrationBusy || !legacyList || legacyList.length === 0, onClick: migrateLegacy, children: migrationBusy ? "正在迁移…" : "迁移 legacy 记录" }),
+                migrationAction && jsx.jsx("span", { className: migrationAction.error ? "dshmu_status dshmu_error" : "dshmu_status", children: migrationAction.error ? `迁移失败：${migrationAction.error}` : migrationAction.success }),
               ] }),
               jsx.jsxs("div", { className: "dshmu_clear", children: [
                 jsx.jsx("span", { className: "dshmu_title", children: "最近同步" }),

--- a/packages/dsh-memory-ui/package.json
+++ b/packages/dsh-memory-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory-ui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "Settings UI for DSH local long-term memory",
   "type": "module",

--- a/packages/dsh-memory/lib/index.js
+++ b/packages/dsh-memory/lib/index.js
@@ -1,7 +1,7 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { homedir, tmpdir } from "node:os";
-import { copyFile, lstat, mkdir, mkdtemp, readFile, realpath, rmdir, unlink, writeFile } from "node:fs/promises";
+import { copyFile, lstat, mkdir, mkdtemp, readFile, realpath, rm, rmdir, unlink, writeFile } from "node:fs/promises";
 import { join, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import z from "@deepseek-ai/schemastery";
@@ -19,6 +19,8 @@ import {
   writeActiveRun,
 } from "./operation-lock.js";
 import { parseFrontMatter, isExpired, topicKey } from "./memory-metadata.js";
+import { legacyRecordSummary, migratedContent, scanLegacyRecords } from "./legacy-migration.js";
+import { SyncTransaction } from "./sync-transaction.js";
 
 const execFile = promisify(execFileCallback);
 const NS = settingsNamespace("memory");
@@ -91,6 +93,11 @@ async function listPayloadFiles(directory, prefix) {
 function layoutError() { return Object.assign(new Error("unsafe memory layout"), { memoryCode: "unsafe-layout" }); }
 function clearError() { return Object.assign(new Error("memory layout changed while clearing"), { memoryCode: "clear-failed" }); }
 function memoryError(code) { return Object.assign(new Error("memory operation failed: " + code), { memoryCode: code }); }
+function migrationErrorCode(error, fallback = "migration-failed") {
+  if (typeof error?.memoryCode === "string") return error.memoryCode;
+  if (typeof error?.code === "string" && error.code !== "ENOENT") return `migration-${error.code}`;
+  return fallback;
+}
 function operationRunId(operation) {
   const timestamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
   return `${timestamp}-${operation}-${process.pid}`;
@@ -341,6 +348,173 @@ export class MemoryRepository {
       return { legacyFileCount, pendingMigration: legacyFileCount > 0 };
     } catch {
       return { legacyFileCount: 0, pendingMigration: false };
+    }
+  }
+
+  /** Return metadata-only descriptions of legacy Markdown records. */
+  async legacyRecords() {
+    try {
+      const root = await this.inspect();
+      const records = await scanLegacyRecords(root);
+      return success({
+        records: records.map(legacyRecordSummary),
+        count: records.length,
+        pendingMigration: records.length > 0,
+      });
+    } catch (error) {
+      return failure(migrationErrorCode(error, "repo-unavailable"));
+    }
+  }
+
+  /**
+   * Add deterministic minimum front matter to legacy records.
+   *
+   * dryRun=true is read-only. The apply path uses the same staging/apply/
+   * journal transaction as model-generated syncs; the model and browser never
+   * receive the live repository path or Git operation.
+   */
+  async migrateLegacy(request = {}) {
+    if (typeof request?.dryRun !== "boolean") return failure("migration-invalid-request");
+    let root;
+    try { root = await this.inspect(); } catch (error) { return failure(migrationErrorCode(error, "repo-unavailable")); }
+
+    let records;
+    try { records = await scanLegacyRecords(root); } catch (error) { return failure(migrationErrorCode(error)); }
+    const summaries = () => records.map(legacyRecordSummary);
+    const emptyResult = (dryRun, status = "no_change") => success({
+      dryRun,
+      status,
+      legacyCount: records.length,
+      migratedCount: 0,
+      changedPaths: dryRun ? records.map((record) => record.path) : [],
+      records: summaries(),
+      recoveryCommit: null,
+      applyCommit: null,
+      journalCommit: null,
+    });
+    if (request.dryRun) return emptyResult(true, records.length === 0 ? "no_change" : "pending");
+    if (records.length === 0) return emptyResult(false);
+
+    const runId = operationRunId("migrate");
+    const startedAt = new Date().toISOString();
+    const transaction = new SyncTransaction(root);
+    let lockAcquired = false;
+    let active;
+    let stagingRoot;
+    let journaled = false;
+    let applied = null;
+    let changedPaths = [];
+    try {
+      await acquireOperationLock(root, { operation: "migrate", runId });
+      lockAcquired = true;
+      const recovered = await transaction.recoverActive();
+      if (recovered?.recovered === true) return failure("interrupted-run");
+      active = {
+        schema_version: 1,
+        run_id: runId,
+        operation: "migrate",
+        status: "running",
+        phase: "staging",
+        pid: process.pid,
+        started_at: startedAt,
+      };
+      await writeActiveRun(root, active);
+
+      // Canonicalize the root after locking before taking the staging
+      // baseline. A second scan follows the snapshot below.
+      root = await this.inspect();
+      stagingRoot = await mkdtemp(join(tmpdir(), "dpsk-memory-migrate-"));
+      const staging = join(stagingRoot, "staging");
+      const manifest = join(stagingRoot, "manifest.json");
+      await transaction.stageCopy(staging, manifest);
+
+      // Stage-copy captures the apply baseline. Scan again after that
+      // snapshot so a concurrent user edit between the first scan and the
+      // copy can never be replaced by stale legacy content. The apply helper
+      // performs one final baseline hash check before touching the live tree.
+      records = await scanLegacyRecords(root);
+      if (records.length === 0) return emptyResult(false);
+
+      active.phase = "validating";
+      await writeActiveRun(root, active);
+      for (const record of records) {
+        await writeFile(join(staging, record.path), migratedContent(record), { mode: 0o600 });
+      }
+      await transaction.verifyStaging(staging, manifest);
+      const diff = await transaction.diff(staging, manifest);
+      changedPaths = [...diff.added, ...diff.modified, ...diff.deleted].sort();
+      if (changedPaths.length === 0) return emptyResult(false);
+
+      active.phase = "applying";
+      await writeActiveRun(root, active);
+      applied = await transaction.apply(staging, manifest, runId, startedAt);
+      active.phase = "finalizing";
+      await writeActiveRun(root, active);
+      const finishedAt = new Date().toISOString();
+      const journal = await transaction.finalize({
+        runId,
+        operation: "migrate",
+        status: applied.status ?? "applied",
+        phase: "complete",
+        startedAt,
+        finishedAt,
+        candidateSessions: 0,
+        processedSessions: 0,
+        skippedSessions: 0,
+        changedPaths: applied.changed_paths ?? changedPaths,
+        recoveryCommit: applied.recovery_commit ?? null,
+        applyCommit: applied.apply_commit ?? null,
+        errorCode: null,
+        durationMs: Math.max(0, Date.parse(finishedAt) - Date.parse(startedAt)),
+        rejectedFileCount: 0,
+      });
+      journaled = true;
+      const migratedPaths = applied.changed_paths ?? changedPaths;
+      return success({
+        dryRun: false,
+        status: applied.status ?? "applied",
+        legacyCount: records.length,
+        migratedCount: migratedPaths.length,
+        changedPaths: migratedPaths,
+        records: summaries(),
+        recoveryCommit: applied.recovery_commit ?? null,
+        applyCommit: applied.apply_commit ?? null,
+        journalCommit: journal?.journal_commit ?? null,
+      });
+    } catch (error) {
+      const code = migrationErrorCode(error);
+      // A normal helper failure is still journaled. If apply had already
+      // returned, its commit is durable and the failure is specifically the
+      // journal/finalization boundary, so do not write a contradictory record.
+      if (lockAcquired && !journaled && applied === null) {
+        try {
+          await transaction.finalize({
+            runId,
+            operation: "migrate",
+            status: "failed",
+            phase: active?.phase ?? "staging",
+            startedAt,
+            finishedAt: new Date().toISOString(),
+            candidateSessions: 0,
+            processedSessions: 0,
+            skippedSessions: 0,
+            changedPaths,
+            recoveryCommit: null,
+            applyCommit: null,
+            errorCode: code,
+            durationMs: Math.max(0, Date.now() - Date.parse(startedAt)),
+            rejectedFileCount: 0,
+          });
+          journaled = true;
+        } catch {}
+      }
+      return failure(code);
+    } finally {
+      if (stagingRoot !== undefined) await rm(stagingRoot, { recursive: true, force: true }).catch(() => {});
+      if (lockAcquired) {
+        await clearActiveRun(root, runId).catch(() => {});
+        await releaseOperationLock(root, runId).catch(() => {});
+      }
     }
   }
 
@@ -771,6 +945,8 @@ export class MemoryService extends TypertRemoteService {
   async setEnabled(request) { return await this.settings.setEnabled(request); }
   async status() { return await this.repository.status(); }
   async health() { return await this.repository.health(); }
+  async legacyRecords() { return await this.repository.legacyRecords(); }
+  async migrateLegacy(request) { return await this.repository.migrateLegacy(request); }
   async clear(request) { return await this.repository.clear(request); }
   async runs(request) { return await this.repository.runs(request); }
   async rollback(request) { return await this.repository.rollback(request); }
@@ -783,6 +959,8 @@ decorate(MemoryService, "getSettings", Remote("getSettings"));
 decorate(MemoryService, "setEnabled", Remote("setEnabled"));
 decorate(MemoryService, "status", Remote("status"));
 decorate(MemoryService, "health", Remote("health"));
+decorate(MemoryService, "legacyRecords", Remote("legacyRecords"));
+decorate(MemoryService, "migrateLegacy", Remote("migrateLegacy"));
 decorate(MemoryService, "clear", Remote("clear"));
 decorate(MemoryService, "runs", Remote("runs"));
 decorate(MemoryService, "rollback", Remote("rollback"));

--- a/packages/dsh-memory/lib/legacy-migration.js
+++ b/packages/dsh-memory/lib/legacy-migration.js
@@ -1,0 +1,91 @@
+/**
+ * Pure legacy-record discovery and front matter generation.
+ *
+ * Migration deliberately does not infer record type, status, confidence, or
+ * body content. It only adds the minimum schema fields needed for a later
+ * consolidation to treat an old Markdown file as structured memory.
+ */
+import { createHash } from "node:crypto";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { parseFrontMatter } from "./memory-metadata.js";
+import { isPayloadPath } from "./memory-tree.js";
+
+const LEGACY_ROOTS = Object.freeze(["handbook", "rollouts", "archive"]);
+
+export function legacyId(path) {
+  const digest = createHash("sha256").update(path).digest("hex").slice(0, 16);
+  return `legacy-${digest}`;
+}
+
+export function migrationFrontMatter(path, mtime) {
+  const date = mtime.toISOString().slice(0, 10);
+  return [
+    "---",
+    "schema_version: 1",
+    `id: ${legacyId(path)}`,
+    `created_at: ${date}`,
+    `updated_at: ${date}`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+export function migratedContent(record) {
+  return migrationFrontMatter(record.path, record.mtime) + record.content;
+}
+
+async function walk(directory) {
+  const files = [];
+  const entries = await readdir(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...await walk(full));
+    else if (entry.isFile()) files.push(full);
+  }
+  return files;
+}
+
+/**
+ * Scan a validated memory root and return records with content for the host
+ * transaction. Callers must not expose the returned content to a browser.
+ */
+export async function scanLegacyRecords(root) {
+  const records = [];
+  for (const directory of LEGACY_ROOTS) {
+    const rootPath = join(root, directory);
+    let files;
+    try {
+      files = await walk(rootPath);
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      throw error;
+    }
+    for (const file of files) {
+      if (!file.endsWith(".md")) continue;
+      const path = relative(root, file);
+      if (!isPayloadPath(path)) continue;
+      const content = await readFile(file, "utf8");
+      if (parseFrontMatter(content, path) !== null) continue;
+      records.push({
+        path,
+        content,
+        mtime: (await stat(file)).mtime,
+      });
+    }
+  }
+  return records.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+/** Metadata-only shape safe to return through the DSH remote API. */
+export function legacyRecordSummary(record) {
+  const date = record.mtime.toISOString().slice(0, 10);
+  return Object.freeze({
+    path: record.path,
+    id: legacyId(record.path),
+    frontMatter: migrationFrontMatter(record.path, record.mtime),
+    createdAt: date,
+    updatedAt: date,
+    bytes: Buffer.byteLength(record.content, "utf8"),
+  });
+}

--- a/packages/dsh-memory/lib/sync-transaction.js
+++ b/packages/dsh-memory/lib/sync-transaction.js
@@ -99,6 +99,10 @@ export class SyncTransaction {
     return await invokePython("apply", { root: this.root, staging, manifest, "run-id": runId, "started-at": startedAt });
   }
 
+  async recoverActive() {
+    return await invokePython("recover-active", { root: this.root });
+  }
+
   async journal(record) {
     const args = {
       root: this.root,
@@ -113,6 +117,10 @@ export class SyncTransaction {
       "recovery-commit": record.recoveryCommit,
       "apply-commit": record.applyCommit,
       "error-code": record.errorCode,
+      phase: record.phase,
+      "staging-digest": record.stagingDigest,
+      "duration-ms": record.durationMs,
+      "rejected-file-count": record.rejectedFileCount ?? 0,
     };
     return await invokePython("journal", args);
   }
@@ -131,6 +139,10 @@ export class SyncTransaction {
       "recovery-commit": record.recoveryCommit,
       "apply-commit": record.applyCommit,
       "error-code": record.errorCode,
+      phase: record.phase,
+      "staging-digest": record.stagingDigest,
+      "duration-ms": record.durationMs,
+      "rejected-file-count": record.rejectedFileCount ?? 0,
       "last-sync": lastSync,
     };
     return await invokePython("finalize", args);

--- a/packages/dsh-memory/package.json
+++ b/packages/dsh-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "Automatic local long-term memory for DSH",
   "type": "module",

--- a/tests/run-memory-tests.sh
+++ b/tests/run-memory-tests.sh
@@ -9,6 +9,7 @@ repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
 cd "$repo_root"
 
 node tests/test_dsh_memory_repository.mjs
+node tests/test_dsh_memory_migration_api.mjs
 node tests/test_dsh_memory_sync_transaction.mjs
 node tests/test_dsh_memory_operation_lock.mjs
 node tests/test_dsh_memory_metadata.mjs

--- a/tests/test_dsh_memory_migration_api.mjs
+++ b/tests/test_dsh_memory_migration_api.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { MemoryRepository } from "../packages/dsh-memory/lib/index.js";
+
+const execFile = promisify(execFileCallback);
+const git = async (root, args) => await execFile("/usr/bin/git", ["-C", root, ...args], { encoding: "utf8" });
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "dsh-memory-migration-api-"));
+  await git(root, ["init"]);
+  await git(root, ["config", "user.name", "DSH Memory Test"]);
+  await git(root, ["config", "user.email", "dsh-memory-test@example.invalid"]);
+  for (const dir of ["handbook", "rollouts", "archive"]) await mkdir(join(root, dir));
+  await writeFile(join(root, "summary.md"), "navigation\n");
+  await writeFile(join(root, "handbook", "legacy-a.md"), "# A\nbody A\n");
+  await writeFile(join(root, "rollouts", "legacy-b.md"), "# B\nbody B\n");
+  await writeFile(join(root, "archive", "legacy-c.md"), "# C\nbody C\n");
+  await writeFile(join(root, "handbook", "structured.md"), "---\nschema_version: 1\nid: structured\n---\nstructured\n");
+  await writeFile(join(root, "README.md"), "reference\n");
+  await writeFile(join(root, ".last-sync"), "0\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "initial legacy memory"]);
+  return root;
+}
+
+const repository = (root) => new MemoryRepository({ root, __testOnly: true });
+
+{
+  const root = await fixture();
+  const service = repository(root);
+  const head = (await git(root, ["rev-parse", "HEAD"])).stdout.trim();
+  const listed = await service.legacyRecords();
+  assert.equal(listed.ok, true, JSON.stringify(listed));
+  assert.equal(listed.value.count, 3);
+  assert.deepEqual(listed.value.records.map((record) => record.path), [
+    "archive/legacy-c.md",
+    "handbook/legacy-a.md",
+    "rollouts/legacy-b.md",
+  ]);
+  for (const record of listed.value.records) {
+    assert.match(record.id, /^legacy-[0-9a-f]{16}$/);
+    assert.match(record.frontMatter, /^---\nschema_version: 1\nid: legacy-[0-9a-f]{16}\ncreated_at: \d{4}-\d{2}-\d{2}\nupdated_at: \d{4}-\d{2}-\d{2}\n---\n$/);
+    assert.equal(Object.hasOwn(record, "content"), false);
+  }
+
+  const dry = await service.migrateLegacy({ dryRun: true });
+  assert.equal(dry.ok, true, JSON.stringify(dry));
+  assert.equal(dry.value.status, "pending");
+  assert.equal(dry.value.dryRun, true);
+  assert.equal(dry.value.legacyCount, 3);
+  assert.deepEqual(dry.value.changedPaths, [
+    "archive/legacy-c.md",
+    "handbook/legacy-a.md",
+    "rollouts/legacy-b.md",
+  ]);
+  assert.equal((await git(root, ["rev-parse", "HEAD"])).stdout.trim(), head);
+  assert.equal(await readFile(join(root, "handbook", "legacy-a.md"), "utf8"), "# A\nbody A\n");
+  assert.equal(await readFile(join(root, ".sync", "last-run.json"), "utf8").catch(() => null), null);
+
+  const applied = await service.migrateLegacy({ dryRun: false });
+  assert.equal(applied.ok, true, JSON.stringify(applied));
+  assert.equal(applied.value.status, "applied");
+  assert.equal(applied.value.migratedCount, 3);
+  assert.equal(applied.value.recoveryCommit, head);
+  assert.match(applied.value.applyCommit, /^[0-9a-f]{40}$/);
+  assert.equal((await git(root, ["rev-parse", `${applied.value.applyCommit}^`])).stdout.trim(), head);
+  assert.match(await readFile(join(root, "handbook", "legacy-a.md"), "utf8"), /^---\nschema_version: 1\nid: legacy-/);
+  assert.match(await readFile(join(root, "handbook", "legacy-a.md"), "utf8"), /# A\nbody A\n$/);
+
+  const status = await service.status();
+  assert.equal(status.ok, true);
+  assert.equal(status.value.legacyFileCount, 0);
+  assert.equal(status.value.pendingMigration, false);
+  const runs = await service.runs({ operation: "migrate", status: "applied", limit: 5 });
+  assert.equal(runs.ok, true);
+  assert.equal(runs.value.runs.length, 1);
+  assert.deepEqual(runs.value.runs[0].changed_paths, applied.value.changedPaths);
+  assert.equal(runs.value.runs[0].recovery_commit, head);
+  assert.equal(runs.value.runs[0].apply_commit, applied.value.applyCommit);
+  assert.equal(runs.value.runs[0].operation, "migrate");
+  assert.equal(runs.value.runs[0].phase, "complete");
+  assert.equal(runs.value.runs[0].duration_ms >= 0, true);
+  assert.equal(runs.value.runs[0].rejected_file_count, 0);
+  assert.equal(JSON.stringify(runs.value.runs[0]).includes("body A"), false);
+
+  const afterHead = (await git(root, ["rev-parse", "HEAD"])).stdout.trim();
+  const again = await service.migrateLegacy({ dryRun: false });
+  assert.equal(again.ok, true, JSON.stringify(again));
+  assert.equal(again.value.status, "no_change");
+  assert.equal((await git(root, ["rev-parse", "HEAD"])).stdout.trim(), afterHead);
+}
+
+{
+  const root = await fixture();
+  await mkdir(join(root, ".sync"));
+  await writeFile(join(root, ".sync", "active-run.json"), JSON.stringify({
+    schema_version: 1,
+    run_id: "stale-migrate",
+    operation: "migrate",
+    status: "running",
+    phase: "applying",
+    pid: -1,
+    started_at: "2026-08-20T00:00:00Z",
+  }) + "\n");
+  const interrupted = await repository(root).migrateLegacy({ dryRun: false });
+  assert.deepEqual(interrupted, { ok: false, error: { code: "interrupted-run" } });
+  assert.equal(await readFile(join(root, ".sync", "active-run.json"), "utf8").catch(() => null), null);
+  const health = await repository(root).health();
+  assert.equal(health.ok, true);
+  assert.equal(health.value.interruptedRun.status, "interrupted");
+  assert.equal(health.value.needsManualRecovery, true);
+  assert.equal((await repository(root).status()).value.legacyFileCount, 3);
+}
+
+{
+  const root = await fixture();
+  assert.deepEqual(await repository(root).migrateLegacy(), { ok: false, error: { code: "migration-invalid-request" } });
+}
+
+console.log("dsh-memory migration API tests passed");

--- a/tests/test_dsh_memory_paths.mjs
+++ b/tests/test_dsh_memory_paths.mjs
@@ -25,6 +25,14 @@ await cp(
   join(project, "packages/dsh-memory/lib/memory-tree.js"),
   join(fixture, "dsh-memory", "lib", "memory-tree.js"),
 );
+await cp(
+  join(project, "packages/dsh-memory/lib/legacy-migration.js"),
+  join(fixture, "dsh-memory", "lib", "legacy-migration.js"),
+);
+await cp(
+  join(project, "packages/dsh-memory/lib/sync-transaction.js"),
+  join(fixture, "dsh-memory", "lib", "sync-transaction.js"),
+);
 await writeFile(join(fixture, "dsh-memory", "package.json"), '{"type":"module"}\n');
 
 const stubs = {

--- a/tests/test_dsh_memory_runtime.sh
+++ b/tests/test_dsh_memory_runtime.sh
@@ -30,7 +30,7 @@ fi
 node -e '
 const p=require(process.argv[1]);
 const peers=["@deepseek-ai/dsh-settings","@deepseek-ai/dsh-typert-protocol","@deepseek-ai/schemastery"];
-if (p.private !== true || p.version !== "0.5.0" || p.exports?.["."] !== "./lib/index.js" || p.type !== "module" || peers.some((name) => !p.peerDependencies?.[name])) process.exit(1);
+if (p.private !== true || p.version !== "0.6.0" || p.exports?.["."] !== "./lib/index.js" || p.type !== "module" || peers.some((name) => !p.peerDependencies?.[name])) process.exit(1);
 ' "$PACKAGE"
 node --check "$HOST"
 python3 -c 'import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text())' "$PROJECT_DIR/packages/dsh-memory/lib/safe-clear.py"

--- a/tests/test_dsh_memory_ui_settings_row.sh
+++ b/tests/test_dsh_memory_ui_settings_row.sh
@@ -13,6 +13,14 @@ grep -Fq -- 'memory.getSettings()' "$CLIENT"
 grep -Fq -- 'memory.setEnabled({ enabled: value })' "$CLIENT"
 grep -Fq -- 'memory.status()' "$CLIENT"
 grep -Fq -- 'memory.clear({ confirmation: "DELETE_MEMORY" })' "$CLIENT"
+grep -Fq -- 'memory.legacyRecords()' "$CLIENT"
+grep -Fq -- 'memory.migrateLegacy({ dryRun: false })' "$CLIENT"
+grep -Fq -- 'dsh-memory#memory/legacyRecords' "$CLIENT"
+grep -Fq -- 'dsh-memory#memory/migrateLegacy' "$CLIENT"
+grep -Fq -- 'const migrationRequest' "$CLIENT"
+grep -Fq -- 'children: "Legacy 记录"' "$CLIENT"
+grep -Fq -- '待迁移' "$CLIENT"
+grep -Fq -- 'record.path} → ${record.id}' "$CLIENT"
 grep -Fq -- 'stage === 2 && phrase !== "删除记忆"' "$CLIENT"
 grep -Fq -- 'className: "dshmu_title", children: "记忆管理"' "$CLIENT"
 grep -Fq -- '~/.dsh/storages/memory' "$CLIENT"
@@ -23,7 +31,7 @@ fi
 node -e '
 const p=require(process.argv[1]);
 const peers=["@deepseek-ai/dsh-api-remotes","@deepseek-ai/dsh-client-connection","@deepseek-ai/dsh-client-runtime","@deepseek-ai/dsh-client-ui-settings","react"];
-if (p.private !== true || p.version !== "0.5.0" || p.exports?.["./client"] !== "./lib/client.js" || p.main !== "./lib/index.js" || peers.some((name) => !p.peerDependencies?.[name])) process.exit(1);
+if (p.private !== true || p.version !== "0.6.0" || p.exports?.["./client"] !== "./lib/client.js" || p.main !== "./lib/index.js" || peers.some((name) => !p.peerDependencies?.[name])) process.exit(1);
 ' "$PACKAGE"
 node --check "$CLIENT"
 print "dsh-memory UI settings row tests passed"

--- a/tools/public-tree-check.mjs
+++ b/tools/public-tree-check.mjs
@@ -52,6 +52,7 @@ const allowed = new Set([
   "packages/dsh-memory/.npmignore",
   "packages/dsh-memory/LICENSE",
   "packages/dsh-memory/lib/index.js",
+  "packages/dsh-memory/lib/legacy-migration.js",
   "packages/dsh-memory/lib/memory-metadata.js",
   "packages/dsh-memory/lib/memory-tree.js",
   "packages/dsh-memory/lib/operation-lock.js",
@@ -72,6 +73,7 @@ const allowed = new Set([
   "tests/test_dsh_memory_operation_lock.mjs",
   "tests/test_dsh_memory_backup.sh",
   "tests/test_dsh_memory_migrate.sh",
+  "tests/test_dsh_memory_migration_api.mjs",
   "tests/test_dsh_memory_paths.mjs",
   "tests/test_dsh_memory_preview.mjs",
   "tests/test_dsh_memory_redaction.mjs",
@@ -221,7 +223,7 @@ try {
       if (content === null) continue;
       try {
         const manifest = JSON.parse(content);
-        if (manifest.version !== "0.5.0") add("manifest version is not 0.5.0", manifestPath);
+        if (manifest.version !== "0.6.0") add("manifest version is not 0.6.0", manifestPath);
         if (manifestPath !== "package.json" && manifest.private !== true) {
           add("package is not locked against npm publication", manifestPath);
         }


### PR DESCRIPTION
## Summary

v0.6.0 turns the standalone `dsh-memory-migrate` CLI into a library API with UI visibility:

- `memory.legacyRecords()` and `memory.migrateLegacy({ dryRun })` in the library layer.
- CLI `dsh-memory-migrate` now reuses the library API (dry-run / apply / idempotent).
- Settings UI gains a "Legacy records" section showing pending files, generated ids, and a confirm-migration button.
- Migration runs through the same staging / lock / recovery+apply commit / journal path as sync; never exposes record bodies.

## Verification

- Full `npm test` suite green (20 groups incl. migrate, backup, preview, sync lock).
- Secret scan, public-tree, release guards pass.
- Both workspaces `npm pack --dry-run` report `0.6.0`.
- Committed as `3358831`, pushed.

## Notes

- Real 23-file migration on the live deepseek-harness memory store not executed (data-write op, deferred for explicit approval).
- No provider calls; Playwright E2E deferred (environment lacks Playwright).