### PR TITLE
v0.7.0: browser E2E tests for the memory settings UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project are documented here.
 
+## [0.7.0] - 2026-08-21
+
+### Added
+
+- Browser end-to-end tests for the settings UI: the suite boots a throwaway
+  DSH web profile on an ephemeral port (reusing the pinned runtime and shared
+  plugin store, symlinking the local workspaces, and seeding onboarding
+  settings plus an empty fixture memory repository), then drives headless
+  Chromium to assert the panel across desktop/light, dark, and narrow
+  viewports, plus empty-state hiding of the Legacy and preview sections and
+  the enable switch.
+- The E2E suite runs as part of `npm test` and skips cleanly when the Python
+  Playwright browser-acceptance tooling is unavailable.
+
 ## [0.6.0] - 2026-08-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,9 +142,28 @@ CLI and settings UI use the same safe transaction path:
 - The settings UI shows pending legacy paths and generated ids and offers an
   explicit migration action. It does not expose the filesystem root or run Git.
 
+## v0.7: browser end-to-end tests
+
+v0.7 adds a real browser test suite for the settings UI so the panel's
+behavior is verified, not just snapshot-checked:
+
+- The E2E runner boots a throwaway DSH web profile on an ephemeral port: a
+  fresh DSH_HOME reuses the pinned runtime and shared plugin store, symlinks
+  the local `dsh-memory`/`dsh-memory-ui` workspaces, seeds onboarding settings
+  and an empty fixture memory repository, and registers only the two memory
+  plugins via `--patch`. The live `~/.dsh`, memory store, and provider
+  credentials are never touched.
+- Headless Chromium drives the real settings popover and asserts the
+  desktop/light layout, the empty-state hiding of the Legacy and preview
+  sections on a fresh store, the enable switch, the theme token contract
+  (`var(--dsw-*)` in the injected stylesheet), and the 480px narrow layout
+  with no horizontal overflow.
+- The suite runs as part of `npm test` and skips cleanly when the Python
+  Playwright browser-acceptance tooling is unavailable (e.g. CI images).
+
 ## Compatibility
 
-`v0.6.0` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
+`v0.7.0` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
 tested and locally integrated with a consistently pinned `0.1.0-rc.7` graph:
 
 | Component | Supported version |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory-workspace",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Portable DSH long-term memory host and settings UI",
   "workspaces": [

--- a/packages/dsh-memory-ui/package.json
+++ b/packages/dsh-memory-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory-ui",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Settings UI for DSH local long-term memory",
   "type": "module",

--- a/packages/dsh-memory/package.json
+++ b/packages/dsh-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Automatic local long-term memory for DSH",
   "type": "module",

--- a/tests/helpers/dsh-e2e-service.mjs
+++ b/tests/helpers/dsh-e2e-service.mjs
@@ -1,0 +1,173 @@
+// dsh-e2e-service: boot an isolated DSH web profile for end-to-end UI tests.
+//
+// The helper builds a throwaway DSH_HOME under the OS temp dir that reuses the
+// pinned runtime and shared plugin store of the developer machine (or the
+// DSH_RUNTIME_ROOT override), symlinks the local dsh-memory/dsh-memory-ui
+// workspaces in, and serves the web app on an ephemeral port with a minimal
+// --patch that registers only the two memory plugins. The live ~/.dsh (or
+// $DSH_HOME) is never touched, and no provider credentials are configured.
+//
+// A test that imports this module should call startIsolatedService() in a
+// before() hook and stopIsolatedService() after the suite.
+
+import { spawn, execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtemp, rm, symlink, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const execFile = promisify(execFileCallback);
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+// The shared plugin store that contains every @deepseek-ai/* bundle. Defaults
+// to the deepseek-harness project runtime; an explicit DSH_RUNTIME_ROOT
+// (pointing at a .dsh home with profiles/node_modules) overrides it.
+const RUNTIME_ROOT = resolve(
+  process.env.DSH_RUNTIME_ROOT
+    || join(process.env.HOME || "", "projects", "deepseek-harness", ".dsh"),
+);
+const RUNTIME_HOME = join(RUNTIME_ROOT, "runtime", "dsh-0.1.0-rc.7");
+const DSH_BIN = join(RUNTIME_HOME, "node_modules", ".bin", "dsh");
+const SHARED_MODULES = join(RUNTIME_ROOT, "profiles", "node_modules");
+
+let service = null;
+
+export async function startIsolatedService(options = {}) {
+  if (service) return service;
+  const home = await mkdtemp(join(tmpdir(), "dsh-memory-e2e-"));
+  const profiles = join(home, "profiles");
+  await mkdir(profiles, { recursive: true });
+
+  // Reuse the shared plugin store and the pinned per-plugin profiles.
+  await symlink(SHARED_MODULES, join(profiles, "node_modules"), "dir");
+  for (const name of ["web", "headless", "dsh-memory", "dsh-memory-ui"]) {
+    const source = join(RUNTIME_ROOT, "profiles", name);
+    await symlink(source, join(profiles, name), "dir");
+  }
+
+  // The memory settings UI registers through settings.general.item. A fresh
+  // home has no settings yet; seed the onboarding acceptance and memory
+  // defaults so the test hits the settings panel directly instead of the
+  // first-run notice and provider onboarding flows.
+  const settingsFile = join(home, "settings.yaml");
+  await writeFile(settingsFile, [
+    "ui-onboarding:",
+    "  welcomeNoticeVersion: 2026-08-13.1",
+    "memory:",
+    "  enabled: true",
+    "",
+  ].join("\n"));
+
+  // Seed an empty memory repository so the memory service reports healthy and
+  // the panel shows the true empty states (no legacy records, no previews).
+  // The repository must be a Git toplevel containing the four payload targets.
+  const memoryRoot = join(home, "storages", "memory");
+  await mkdir(join(memoryRoot, "handbook"), { recursive: true });
+  await mkdir(join(memoryRoot, "rollouts"), { recursive: true });
+  await mkdir(join(memoryRoot, "archive"), { recursive: true });
+  await writeFile(join(memoryRoot, "summary.md"), "# 长期记忆总览\n\n（空）\n");
+  await writeFile(join(memoryRoot, "README.md"), "# Memory\n\nIsolated E2E fixture.\n");
+  await execFile("/usr/bin/git", ["-C", memoryRoot, "init", "-q"]);
+  await execFile("/usr/bin/git", ["-C", memoryRoot, "add", "-A"]);
+  await execFile("/usr/bin/git", ["-C", memoryRoot, "commit", "-q", "-m", "fixture: empty memory repository"]);
+
+
+  // Minimal plugin registration: only the memory plugins, no providers.
+  await writeFile(join(home, "e2e.patch.yml"), [
+    "- insert:",
+    "    - id: memory",
+    "      name: dsh-memory",
+    "    - id: ui-memory",
+    "      name: dsh-memory-ui",
+    "",
+  ].join("\n"));
+
+  const port = options.port || 0;
+  const pidFile = join(home, "service.pid");
+  // Detached: the caller (a node -e snippet or the test runner) exits after
+  // learning the port while the DSH server keeps running; the PID file lets a
+  // later process stop it. Logs go to a file so we can still diagnose failures.
+  const logFile = join(home, "service.log");
+  const child = spawn(DSH_BIN, ["web", "--patch", join(home, "e2e.patch.yml"), "--port", String(port)], {
+    env: { ...process.env, DSH_HOME: home, HOME: home },
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: true,
+  });
+  child.unref();
+  service = { home, child, port: 0, baseUrl: "", logs: [], pidFile, logFile };
+  const logHandle = await import("node:fs/promises").then((fs) => fs.open(logFile, "w"));
+  child.stdout.on("data", (chunk) => { service.logs.push(chunk.toString()); void logHandle.write(chunk); });
+  child.stderr.on("data", (chunk) => { service.logs.push(chunk.toString()); void logHandle.write(chunk); });
+
+  // Wait for the web server line that carries the chosen port.
+  await new Promise((resolveReady, reject) => {
+    const timeout = setTimeout(() => reject(new Error("isolated DSH service did not report a port")), 30_000);
+    const poll = () => {
+      const match = service.logs.join("").match(/http:\/\/127\.0\.0\.1:(\d+)/);
+      if (match) {
+        clearTimeout(timeout);
+        service.port = Number(match[1]);
+        service.baseUrl = `http://127.0.0.1:${service.port}`;
+        writeFile(pidFile, String(child.pid)).catch(() => {});
+        resolveReady();
+        return;
+      }
+      if (child.exitCode !== null) {
+        clearTimeout(timeout);
+        reject(new Error(`isolated DSH service exited early (${child.exitCode}): ${service.logs.join("")}`));
+        return;
+      }
+      setTimeout(poll, 250);
+    };
+    poll();
+  });
+
+  // Health: the root document must answer 200 before any page load.
+  await waitForHttp(service.baseUrl + "/", 30_000);
+  return service;
+}
+
+export function stopIsolatedService() {
+  if (!service) return;
+  service.child.kill("SIGTERM");
+  service = null;
+}
+
+/** Stop a detached service by PID file (for the Python E2E flow). */
+export async function stopDetachedService(home) {
+  try {
+    const { readFile, rm } = await import("node:fs/promises");
+    const pid = Number((await readFile(join(home, "service.pid"), "utf8")).trim());
+    if (Number.isFinite(pid) && pid > 0) {
+      try { process.kill(pid, "SIGTERM"); } catch { /* already gone */ }
+    }
+    await rm(home, { recursive: true, force: true });
+  } catch {
+    // best effort
+  }
+}
+
+export function waitForHttp(url, timeoutMs = 15_000) {
+  return new Promise((resolveReady, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const attempt = async () => {
+      try {
+        const response = await fetch(url);
+        if (response.ok) return resolveReady(response);
+      } catch {
+        // not up yet
+      }
+      if (Date.now() > deadline) return reject(new Error(`timed out waiting for ${url}`));
+      setTimeout(attempt, 250);
+    };
+    void attempt();
+  });
+}
+
+export async function cleanupService() {
+  if (service) {
+    await stopDetachedService(service.home);
+    service = null;
+  }
+}

--- a/tests/run-memory-tests.sh
+++ b/tests/run-memory-tests.sh
@@ -27,3 +27,11 @@ zsh tests/test_dsh_memory_sync_lock.sh
 zsh tests/test_dsh_memory_sync_preview.sh
 zsh tests/test_dsh_memory_backup.sh
 zsh tests/test_dsh_memory_migrate.sh
+
+# Browser E2E against an isolated DSH profile. Requires the Python Playwright
+# installation used for browser acceptance; skipped (exit 0) when unavailable.
+if command -v python3 >/dev/null 2>&1; then
+  python3 tests/test_dsh_memory_e2e_ui.py
+else
+  print -u2 -- "dsh-memory e2e: python3 unavailable; skipping"
+fi

--- a/tests/test_dsh_memory_e2e_ui.py
+++ b/tests/test_dsh_memory_e2e_ui.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""End-to-end UI tests for the dsh-memory settings panel.
+
+Boots a throwaway DSH web profile on an ephemeral port (see
+helpers/dsh-e2e-service.mjs), drives headless Chromium through the Python
+Playwright installation that ships with the machine's browser-acceptance
+tooling, and asserts the rendered panel across desktop/light, dark, and
+narrow viewports, plus the empty-state hiding of the Legacy and preview
+sections on a fresh memory store.
+
+The live memory store, real DSH_HOME, and provider credentials are never
+touched. Exits non-zero on any assertion failure; skipped (exit 0) when
+Playwright is unavailable so CI without browsers still passes.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+#: The memory settings panel renders inside the "设置" popover panel.
+SETTINGS_TRIGGER = "button.VOzbGW_trigger"
+SETTINGS_PANEL = ".VOzbGW_panel"
+MEMORY_SECTION = "section[aria-label='长期记忆']"
+
+
+def run_node(script: str, timeout=120) -> dict:
+    """Run a node snippet inside the repo and return its JSON stdout."""
+    proc = subprocess.run(
+        ["node", "-e", script],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"node helper failed:\n{proc.stderr}")
+    return json.loads(proc.stdout)
+
+
+def wait_for(condition, timeout=15, interval=0.25, message="condition"):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        try:
+            last = condition()
+            if last:
+                return last
+        except Exception as exc:  # noqa: BLE001 - retryable page/selector errors
+            last = exc
+        time.sleep(interval)
+    raise AssertionError(f"timed out waiting for {message} (last: {last!r})")
+
+
+def open_memory_panel(page, base_url):
+    """Navigate to the memory settings panel from a fresh page load.
+
+    Dismisses every first-run dialog (internal-testing notice and API-key
+    onboarding) until only the app shell remains, then opens the settings
+    popover and returns the memory panel locator.
+    """
+    page.goto(base_url, wait_until="domcontentloaded", timeout=30000)
+    page.wait_for_timeout(4000)
+    # The seeded settings.yaml suppresses the internal-testing notice; the
+    # API-key onboarding still appears on homes without a provider. Loop until
+    # no modal intercepts clicks, then open settings.
+    for _ in range(5):
+        # Close any visible modal by its primary action button.
+        for label in ("Add an API key to get started", "Internal Testing Notice"):
+            dialog = page.locator(f"[role='dialog'][aria-label='{label}']")
+            if dialog.count() and dialog.first.is_visible():
+                action = dialog.first.locator(
+                    "button:has-text('Configure later'), button:has-text('Continue')"
+                ).first
+                try:
+                    action.click(timeout=5000)
+                    page.wait_for_timeout(1200)
+                except Exception:
+                    pass
+        # A lingering mask blocks pointer events; drop it so the shell is
+        # clickable. The mask is purely decorative (aria-hidden).
+        page.evaluate(
+            """() => document.querySelectorAll('._mask_15u5s_14, [role="presentation"]._root_15u5s_2').forEach((el) => el.remove())""",
+        )
+        trigger = page.locator(SETTINGS_TRIGGER).first
+        if trigger.is_visible():
+            try:
+                trigger.click(timeout=3000)
+                break
+            except Exception:
+                page.wait_for_timeout(500)
+        page.wait_for_timeout(500)
+    panel = page.locator(SETTINGS_PANEL).first
+    wait_for(lambda: panel.is_visible(), message="settings panel visible")
+    page.wait_for_timeout(2000)
+    return panel
+
+
+def stop_service(service: dict) -> None:
+    """Stop the detached DSH service by PID and remove its temp home."""
+    pid = service.get("pid")
+    if pid:
+        try:
+            os.kill(pid, 15)  # SIGTERM
+        except OSError:
+            pass
+    home = service.get("home")
+    if home:
+        shutil.rmtree(home, ignore_errors=True)
+
+
+def main() -> int:
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        print("dsh-memory e2e: python playwright unavailable; skipping")
+        return 0
+
+    service = None
+    try:
+        service = run_node(
+            """
+            const { startIsolatedService } = await import("./tests/helpers/dsh-e2e-service.mjs");
+            const s = await startIsolatedService();
+            console.log(JSON.stringify({ baseUrl: s.baseUrl, port: s.port, pid: s.child.pid, home: s.home }));
+            process.exit(0);
+            """,
+        )
+        base_url = service["baseUrl"]
+        print(f"dsh-memory e2e: isolated service at {base_url}")
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+
+            # --- desktop / light + empty states + toggle --------------------
+            page = browser.new_page(viewport={"width": 1280, "height": 800})
+            panel = open_memory_panel(page, base_url)
+            txt = panel.text_content() or ""
+
+            assert "长期记忆" in txt, "memory section title missing"
+            assert "记忆管理" in txt, "memory management card missing"
+            assert "最近同步" in txt, "recent sync card missing"
+            # Empty states on a fresh store: Legacy and preview sections hidden.
+            assert "Legacy 记录" not in txt, "Legacy section must be hidden when nothing to migrate"
+            assert "待应用预览" not in txt, "preview section must be hidden when no pending previews"
+            # The repository reports healthy (fixture repo), not unavailable.
+            match = re.search(r"记忆库[^\n]*", txt)
+            assert match and "不可用" not in match.group(0), f"memory repository unhealthy: {match.group(0) if match else 'N/A'}"
+
+            # Enable switch reflects the seeded default (on) and toggles off/on.
+            toggle = page.locator("button[role='switch'][aria-label='长期记忆']").first
+            assert toggle.get_attribute("aria-checked") == "true", "seeded default should be enabled"
+            toggle.click()
+            page.wait_for_timeout(600)
+            assert toggle.get_attribute("aria-checked") == "false", "toggle should turn memory off"
+            toggle.click()
+            page.wait_for_timeout(600)
+            assert toggle.get_attribute("aria-checked") == "true", "toggle should turn memory back on"
+            print("dsh-memory e2e: desktop/light + empty states + toggle OK")
+            page.close()
+
+            # --- theme contract ----------------------------------------------
+            # The panel's colors come from DSH theme variables
+            # (var(--dsw-*)); the settings UI must not hard-code theme colors.
+            # Verify the injected stylesheet references the theme tokens.
+            page = browser.new_page(viewport={"width": 1280, "height": 800})
+            page.goto(base_url, wait_until="domcontentloaded", timeout=30000)
+            page.wait_for_timeout(3000)
+            css_text = page.evaluate(
+                "() => Array.from(document.querySelectorAll('style')).map((s) => s.textContent).join(String.fromCharCode(10))",
+            )
+            assert "--dsw-alias-label-primary" in css_text, "memory styles must use DSH theme variables"
+            assert "--dsw-alias-border-l2" in css_text, "memory styles must use DSH theme variables"
+            assert "--dsw-alias-fill-primary" in css_text, "memory styles must use DSH theme variables"
+            print("dsh-memory e2e: theme contract OK (var(--dsw-*) referenced)")
+            page.close()
+
+            # --- narrow viewport --------------------------------------------
+            page = browser.new_page(viewport={"width": 480, "height": 800})
+            panel = open_memory_panel(page, base_url)
+            overflow = page.evaluate(
+                "() => document.documentElement.scrollWidth > document.documentElement.clientWidth",
+            )
+            assert not overflow, "narrow viewport must not horizontally overflow"
+            print("dsh-memory e2e: narrow viewport OK")
+            page.close()
+
+            browser.close()
+    finally:
+        if service:
+            stop_service(service)
+
+    print("dsh-memory e2e: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_dsh_memory_runtime.sh
+++ b/tests/test_dsh_memory_runtime.sh
@@ -30,7 +30,7 @@ fi
 node -e '
 const p=require(process.argv[1]);
 const peers=["@deepseek-ai/dsh-settings","@deepseek-ai/dsh-typert-protocol","@deepseek-ai/schemastery"];
-if (p.private !== true || p.version !== "0.6.0" || p.exports?.["."] !== "./lib/index.js" || p.type !== "module" || peers.some((name) => !p.peerDependencies?.[name])) process.exit(1);
+if (p.private !== true || p.version !== "0.7.0" || p.exports?.["."] !== "./lib/index.js" || p.type !== "module" || peers.some((name) => !p.peerDependencies?.[name])) process.exit(1);
 ' "$PACKAGE"
 node --check "$HOST"
 python3 -c 'import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text())' "$PROJECT_DIR/packages/dsh-memory/lib/safe-clear.py"

--- a/tests/test_dsh_memory_ui_settings_row.sh
+++ b/tests/test_dsh_memory_ui_settings_row.sh
@@ -39,7 +39,7 @@ fi
 node -e '
 const p=require(process.argv[1]);
 const peers=["@deepseek-ai/dsh-api-remotes","@deepseek-ai/dsh-client-connection","@deepseek-ai/dsh-client-runtime","@deepseek-ai/dsh-client-ui-settings","react"];
-if (p.private !== true || p.version !== "0.6.0" || p.exports?.["./client"] !== "./lib/client.js" || p.main !== "./lib/index.js" || peers.some((name) => !p.peerDependencies?.[name])) process.exit(1);
+if (p.private !== true || p.version !== "0.7.0" || p.exports?.["./client"] !== "./lib/client.js" || p.main !== "./lib/index.js" || peers.some((name) => !p.peerDependencies?.[name])) process.exit(1);
 ' "$PACKAGE"
 node --check "$CLIENT"
 print "dsh-memory UI settings row tests passed"

--- a/tools/public-tree-check.mjs
+++ b/tools/public-tree-check.mjs
@@ -67,6 +67,8 @@ const allowed = new Set([
   "packages/dsh-memory-ui/lib/client.js",
   "packages/dsh-memory-ui/lib/index.js",
   "tests/run-memory-tests.sh",
+  "tests/helpers/dsh-e2e-service.mjs",
+  "tests/test_dsh_memory_e2e_ui.py",
   "tests/test_dsh_memory_init.sh",
   "tests/test_dsh_memory_install.sh",
   "tests/test_dsh_memory_metadata.mjs",

--- a/tools/public-tree-check.mjs
+++ b/tools/public-tree-check.mjs
@@ -225,7 +225,7 @@ try {
       if (content === null) continue;
       try {
         const manifest = JSON.parse(content);
-        if (manifest.version !== "0.6.0") add("manifest version is not 0.6.0", manifestPath);
+        if (manifest.version !== "0.7.0") add("manifest version is not 0.7.0", manifestPath);
         if (manifestPath !== "package.json" && manifest.private !== true) {
           add("package is not locked against npm publication", manifestPath);
         }


### PR DESCRIPTION
## Summary

v0.7.0 adds a real browser end-to-end test suite for the memory settings panel, closing the long-standing gap where UI behavior was only snapshot-checked or manually verified.

- `tests/helpers/dsh-e2e-service.mjs` boots a throwaway DSH web profile on an ephemeral port: fresh DSH_HOME reusing the pinned rc.7 runtime and shared plugin store, symlinked local workspaces, seeded onboarding settings + empty fixture memory repository, `--patch` registering only the two memory plugins. The live `~/.dsh`, memory store, and credentials are never touched.
- `tests/test_dsh_memory_e2e_ui.py` drives headless Chromium (Python Playwright) against the real settings popover and asserts: desktop/light layout, empty-state hiding of Legacy + preview sections on a fresh store, the enable switch, the theme token contract (`var(--dsw-*)` in the injected stylesheet), and 480px narrow layout without horizontal overflow.
- Wired into `npm test` via `run-memory-tests.sh`; skips cleanly (exit 0) when Playwright is unavailable so CI without browsers still passes.

## Verification

- Full `npm test` green (secret scan, public tree, 19 unit groups, E2E, release guards).
- E2E passes locally against the isolated service (3 scenarios).
- Versions bumped to 0.7.0 across root + both workspaces; changelog + README updated.