### PR TITLE
fix: sync v0.7.0 metadata and make scheduled sync launchd-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- LaunchAgent sync now discovers a local Node runtime when launchd provides a
+  minimal `PATH`, so the pinned `#!/usr/bin/env node` DSH launcher does not
+  fail before headless consolidation.
+- Workspace and package lock metadata now consistently records v0.7.0.
+
 ## [0.7.0] - 2026-08-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -189,14 +189,14 @@ Clone the repository and install its reproducible development/runtime dependenci
 ```zsh
 git clone https://github.com/seriousz158/dsh-memory.git
 cd dsh-memory
-# Use the pinned runtime that this v0.6.0 integration was tested with.
+# Use the pinned runtime that this v0.7.0 integration was tested with.
 npm install --global @deepseek-ai/dsh@0.1.0-rc.7
 dsh --version
 npm ci --ignore-scripts
 ```
 
 This is a source-and-GitHub-Release project. Both workspace packages are
-intentionally marked private, so `v0.6.0` cannot be published to npm by
+intentionally marked private, so `v0.7.0` cannot be published to npm by
 accident.
 
 Install the two local packages into your DSH profile. The installer defaults to

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -81,7 +81,7 @@ used during installation.
 
 The sync command does not install DSH. It requires a `dsh` executable on `PATH`, or a deliberately configured `DSH_BIN`. It performs no work while `memory.enabled` is false.
 
-The v0.6.0 host and UI packages still declare the runtime peer range
+The v0.7.0 host and UI packages still declare the runtime peer range
 `@deepseek-ai/dsh@^0.1.0-rc.6`, so DSH `rc.6` remains peer-compatible. The
 repository's reproducible clean-room and local integration baseline is
 `0.1.0-rc.7`, because the registry's `rc.6` transitive peer graph is not

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,6 +80,8 @@ loading it: a LaunchAgent does not reliably inherit the one-time shell exports
 used during installation.
 
 The sync command does not install DSH. It requires a `dsh` executable on `PATH`, or a deliberately configured `DSH_BIN`. It performs no work while `memory.enabled` is false.
+The wrapper also discovers a local Homebrew or nvm Node runtime when launchd
+starts with a minimal `PATH`; no interactive shell profile is required.
 
 The v0.7.0 host and UI packages still declare the runtime peer range
 `@deepseek-ai/dsh@^0.1.0-rc.6`, so DSH `rc.6` remains peer-compatible. The

--- a/integrations/dsh/dsh-memory-sync
+++ b/integrations/dsh/dsh-memory-sync
@@ -79,25 +79,35 @@ command -v "$PYTHON_BIN" >/dev/null 2>&1 || { print -u2 -- "dsh-memory-sync: pyt
 resolve_node_executable() {
   setopt local_options null_glob numeric_glob_sort
   local candidate
+  local version_major
+  local i
   typeset -a nvm_candidates
+  is_supported_node() {
+    [[ -x "$1" ]] || return 1
+    version_major="$($1 --version 2>/dev/null | /usr/bin/sed -E 's/^v([0-9]+).*/\1/' || true)"
+    [[ "$version_major" =~ '^[0-9]+$' ]] && (( version_major >= 22 ))
+  }
   candidate="$(command -v node 2>/dev/null || true)"
-  if [[ -n "$candidate" && -x "$candidate" ]]; then
+  if [[ -n "$candidate" ]] && is_supported_node "$candidate"; then
     print -r -- "$candidate"
     return 0
   fi
   # Prefer stable system/Homebrew locations, then the numerically newest nvm
   # installation (v22 over an older v20, for example).
   for candidate in /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
-    if [[ -x "$candidate" ]]; then
+    if is_supported_node "$candidate"; then
       print -r -- "$candidate"
       return 0
     fi
   done
   nvm_candidates=("$HOME"/.nvm/versions/node/*/bin/node(N))
-  if (( ${#nvm_candidates} > 0 )); then
-    print -r -- "${nvm_candidates[-1]}"
-    return 0
-  fi
+  for (( i=${#nvm_candidates}; i >= 1; i-- )); do
+    candidate="${nvm_candidates[i]}"
+    if is_supported_node "$candidate"; then
+      print -r -- "$candidate"
+      return 0
+    fi
+  done
   return 1
 }
 

--- a/integrations/dsh/dsh-memory-sync
+++ b/integrations/dsh/dsh-memory-sync
@@ -84,7 +84,7 @@ resolve_node_executable() {
   typeset -a nvm_candidates
   is_supported_node() {
     [[ -x "$1" ]] || return 1
-    version_major="$($1 --version 2>/dev/null | /usr/bin/sed -E 's/^v([0-9]+).*/\1/' || true)"
+    version_major="$("$1" --version 2>/dev/null | /usr/bin/sed -E 's/^v([0-9]+).*/\1/' || true)"
     [[ "$version_major" =~ '^[0-9]+$' ]] && (( version_major >= 22 ))
   }
   candidate="$(command -v node 2>/dev/null || true)"

--- a/integrations/dsh/dsh-memory-sync
+++ b/integrations/dsh/dsh-memory-sync
@@ -71,6 +71,46 @@ fi
 PYTHON_BIN="${DPSK_PYTHON3:-python3}"
 command -v "$PYTHON_BIN" >/dev/null 2>&1 || { print -u2 -- "dsh-memory-sync: python3 is required"; exit 127; }
 
+# launchd starts agents with a minimal PATH. The pinned DSH launcher is a
+# `#!/usr/bin/env node` script, so make a discovered Node runtime available to
+# the isolated child even when the LaunchAgent was not loaded from a shell
+# that initialized nvm/Homebrew. Explicit PATH entries still win; this is only
+# a fail-closed compatibility fallback for the local runtime.
+resolve_node_executable() {
+  setopt local_options null_glob numeric_glob_sort
+  local candidate
+  typeset -a nvm_candidates
+  candidate="$(command -v node 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]]; then
+    print -r -- "$candidate"
+    return 0
+  fi
+  # Prefer stable system/Homebrew locations, then the numerically newest nvm
+  # installation (v22 over an older v20, for example).
+  for candidate in /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do
+    if [[ -x "$candidate" ]]; then
+      print -r -- "$candidate"
+      return 0
+    fi
+  done
+  nvm_candidates=("$HOME"/.nvm/versions/node/*/bin/node(N))
+  if (( ${#nvm_candidates} > 0 )); then
+    print -r -- "${nvm_candidates[-1]}"
+    return 0
+  fi
+  return 1
+}
+
+NODE_EXECUTABLE="$(resolve_node_executable || true)"
+RUNTIME_PATH="${PATH:-/usr/bin:/bin:/usr/sbin:/sbin}"
+if [[ -n "$NODE_EXECUTABLE" ]]; then
+  NODE_DIR="$(dirname -- "$NODE_EXECUTABLE")"
+  case ":$RUNTIME_PATH:" in
+    *":$NODE_DIR:"*) ;;
+    *) RUNTIME_PATH="$NODE_DIR:$RUNTIME_PATH" ;;
+  esac
+fi
+
 # In --json mode every progress line is suppressed from stdout so the single
 # JSON document on stdout stays machine-parseable; diagnostics still go to stderr.
 progress() {
@@ -123,7 +163,7 @@ BASE_ENV=(
   "HOME=${HOME:?HOME is required}"
   "DSH_HOME=$DSH_HOME"
   "DSH_MEMORY_ROOT=$DSH_MEMORY_ROOT"
-  "PATH=${PATH:-/usr/bin:/bin:/usr/sbin:/sbin}"
+  "PATH=$RUNTIME_PATH"
   "TMPDIR=${TMPDIR:-/tmp}"
   "LANG=${LANG:-C}"
 )

--- a/integrations/dsh/dsh-memory-sync.plist.example
+++ b/integrations/dsh/dsh-memory-sync.plist.example
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- The sync wrapper discovers a local Node runtime even under launchd's
+     minimal PATH; no interactive shell profile is required. -->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-memory-workspace",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-memory-workspace",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "workspaces": [
         "packages/dsh-memory",
         "packages/dsh-memory-ui"
@@ -1131,7 +1131,7 @@
       }
     },
     "packages/dsh-memory": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "engines": {
         "node": ">=22"
@@ -1143,7 +1143,7 @@
       }
     },
     "packages/dsh-memory-ui": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/tests/test_dsh_memory_sync_env.sh
+++ b/tests/test_dsh_memory_sync_env.sh
@@ -97,13 +97,38 @@ for forbidden_name in \
   fi
 done
 
+# launchd supplies a minimal PATH. The sync wrapper must still be able to run
+# a standard `#!/usr/bin/env node` DSH launcher by discovering Homebrew/nvm
+# Node, without requiring a shell profile to be sourced.
+NODE_SHEBANG_DSH="$TEST_BIN/node-shebang-dsh"
+cat > "$NODE_SHEBANG_DSH" <<'EOF'
+#!/usr/bin/env node
+const fs = require("node:fs");
+fs.writeFileSync("handbook/node-launchd-entry.md", "synthetic node launchd entry\n");
+EOF
+chmod +x "$NODE_SHEBANG_DSH"
+touch -t 200001010000 "$TEST_MEMORY_ROOT/.last-sync"
+touch -t 200001010001 "$TEST_DSH_HOME/sessions/session.jsonl.zstd"
+env \
+  HOME="$TEST_HOME" \
+  DSH_HOME="$TEST_DSH_HOME" \
+  DSH_MEMORY_ROOT="$TEST_MEMORY_ROOT" \
+  DSH_BIN="$NODE_SHEBANG_DSH" \
+  DPSK_MEMORY_SYNC_HELPER="$TEST_INTEGRATION/sync-apply.py" \
+  PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+  zsh "$TEST_INTEGRATION/dsh-memory-sync" >/dev/null
+[[ -f "$TEST_MEMORY_ROOT/handbook/node-launchd-entry.md" ]] || {
+  print -u2 -- "minimal PATH node shebang launcher did not apply"
+  exit 1
+}
+
 /usr/bin/python3 - "$TEST_MEMORY_ROOT/.sync/runs" <<'PY'
 import json
 import pathlib
 import sys
 
 run_files = sorted(pathlib.Path(sys.argv[1]).glob("*.json"))
-assert len(run_files) == 1, run_files
+assert len(run_files) >= 2, run_files
 record = json.loads(run_files[0].read_text())
 assert record["candidate_sessions"] == 1, record
 assert record["processed_sessions"] == 1, record


### PR DESCRIPTION
## Summary

Synchronizes the release metadata that the audit flagged and fixes a real
LaunchAgent fault surfaced while repairing the audit findings.

- **docs:** bump remaining `v0.6.0` install/publication references to
  `v0.7.0` in README and docs/installation.md; changelog notes the repair.
- **sync (launchd-safe):** `dsh-memory-sync` now discovers a supported Node
  22+ runtime (Homebrew `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`,
  then nvm) because launchd starts agents with a minimal PATH and the pinned
  DSH launcher is a `#!/usr/bin/env node` script — previously the scheduled
  run failed with `env: node: No such file or directory` (exit 127).
- **plist.example:** documents the Node-discovery behavior.
- **tests:** `test_dsh_memory_sync_env.sh` covers the Node resolution and
  PATH assembly paths.

## Verification

- Full `npm test` green (secret scan, public tree, 19 unit groups, Chromium
  E2E, release guards).
- Both workspaces `npm pack --dry-run` report `0.7.0`.
- LaunchAgent smoke with a minimal PATH passes; `dpsk-preflight` passes.