### PR TITLE
Remove legacy migration controls from memory UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project are documented here.
   minimal `PATH`, so the pinned `#!/usr/bin/env node` DSH launcher does not
   fail before headless consolidation.
 - Workspace and package lock metadata now consistently records v0.7.0.
+- Removed the Legacy migration card and controls from the settings UI; the
+  host API and `dsh-memory-migrate` CLI remain available.
 
 ## [0.7.0] - 2026-08-21
 

--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ v0.5 adds operational tooling around the memory store:
   unsupported) and the integration tool defaults.
 - The release checklist now verifies the backup round-trip before release.
 
-## v0.6: library-backed legacy migration and UI visibility
+## v0.6: library-backed legacy migration
 
 v0.6 moves legacy-record inspection and migration into the host library so the
-CLI and settings UI use the same safe transaction path:
+CLI and host API use the same safe transaction path:
 
 - `memory.legacyRecords()` returns metadata-only entries for legacy Markdown
   files (path, deterministic id, generated front matter, dates, and size).
@@ -139,8 +139,9 @@ CLI and settings UI use the same safe transaction path:
 - `dsh-memory-migrate --dry-run` and `--apply` delegate to those library APIs.
   The journal records operation metadata only; it never contains memory body,
   transcript, prompt, or credential content.
-- The settings UI shows pending legacy paths and generated ids and offers an
-  explicit migration action. It does not expose the filesystem root or run Git.
+- The settings UI intentionally does not expose legacy migration controls. Use
+  `dsh-memory-migrate --dry-run|--apply` or the host API when migration is
+  explicitly needed; the UI never exposes the filesystem root or runs Git.
 
 ## v0.7: browser end-to-end tests
 
@@ -154,10 +155,10 @@ behavior is verified, not just snapshot-checked:
   plugins via `--patch`. The live `~/.dsh`, memory store, and provider
   credentials are never touched.
 - Headless Chromium drives the real settings popover and asserts the
-  desktop/light layout, the empty-state hiding of the Legacy and preview
-  sections on a fresh store, the enable switch, the theme token contract
-  (`var(--dsw-*)` in the injected stylesheet), and the 480px narrow layout
-  with no horizontal overflow.
+  desktop/light layout, absence of the removed Legacy migration UI, empty
+  preview state, the enable switch, the theme token contract (`var(--dsw-*)`
+  in the injected stylesheet), and the 480px narrow layout with no horizontal
+  overflow.
 - The suite runs as part of `npm test` and skips cleanly when the Python
   Playwright browser-acceptance tooling is unavailable (e.g. CI images).
 

--- a/packages/dsh-memory-ui/lib/client.js
+++ b/packages/dsh-memory-ui/lib/client.js
@@ -13,15 +13,12 @@ window.__ModuleLoader__.load({
       return transport.ok ? result(transport.value) : transport;
     };
     const enabledRequest = (value) => { if (!value || typeof value !== "object" || typeof value.enabled !== "boolean") throw new Error("invalid memory setting request"); return value; };
-    const migrationRequest = (value) => { if (!value || typeof value !== "object" || typeof value.dryRun !== "boolean") throw new Error("invalid migration request"); return value; };
     const rollbackRequest = (value) => { if (!value || value.confirmation !== "ROLLBACK_MEMORY" || typeof value.runId !== "string" || value.runId.length === 0) throw new Error("invalid rollback request"); return value; };
     const remote = { package: "dsh-memory", descriptors: [
       { id: "dsh-memory#memory/getSettings", service: "memory", namespace: "memory", method: "getSettings", invocation: { kind: "direct" }, parameters: [], result: strict(result) },
       { id: "dsh-memory#memory/setEnabled", service: "memory", namespace: "memory", method: "setEnabled", invocation: { kind: "direct" }, parameters: [{ name: "request", wire: "request", source: "json", codec: strict(enabledRequest) }], result: strict(result) },
       { id: "dsh-memory#memory/status", service: "memory", namespace: "memory", method: "status", invocation: { kind: "direct" }, parameters: [], result: strict(result) },
       { id: "dsh-memory#memory/health", service: "memory", namespace: "memory", method: "health", invocation: { kind: "direct" }, parameters: [], result: strict(result) },
-      { id: "dsh-memory#memory/legacyRecords", service: "memory", namespace: "memory", method: "legacyRecords", invocation: { kind: "direct" }, parameters: [], result: strict(result) },
-      { id: "dsh-memory#memory/migrateLegacy", service: "memory", namespace: "memory", method: "migrateLegacy", invocation: { kind: "direct" }, parameters: [{ name: "request", wire: "request", source: "json", codec: strict(migrationRequest) }], result: strict(result) },
       { id: "dsh-memory#memory/clear", service: "memory", namespace: "memory", method: "clear", invocation: { kind: "direct" }, parameters: [{ name: "request", wire: "request", source: "json", codec: strict((value) => { if (!value || value.confirmation !== "DELETE_MEMORY") throw new Error("invalid clear request"); return value; }) }], result: strict(result) },
       { id: "dsh-memory#memory/runs", service: "memory", namespace: "memory", method: "runs", invocation: { kind: "direct" }, parameters: [{ name: "request", wire: "request", source: "json", codec: strict((value) => { if (value !== undefined && value !== null && typeof value !== "object") throw new Error("invalid runs request"); return value; }) }], result: strict(result) },
       { id: "dsh-memory#memory/rollback", service: "memory", namespace: "memory", method: "rollback", invocation: { kind: "direct" }, parameters: [{ name: "request", wire: "request", source: "json", codec: strict(rollbackRequest) }], result: strict(result) },
@@ -130,10 +127,6 @@ window.__ModuleLoader__.load({
             const [repositoryRevision, setRepositoryRevision] = react.useState(0);
             const [rollbackState, setRollbackState] = react.useState(null);
             const [rollbackBusy, setRollbackBusy] = react.useState(false);
-            const [legacyList, setLegacyList] = react.useState(null);
-            const [legacyError, setLegacyError] = react.useState(null);
-            const [migrationBusy, setMigrationBusy] = react.useState(false);
-            const [migrationAction, setMigrationAction] = react.useState(null);
             react.useEffect(() => {
               let disposed = false;
               const load = async () => {
@@ -142,22 +135,6 @@ window.__ModuleLoader__.load({
                   if (!disposed) setRepository(answer.ok ? { value: answer.value } : { error: answer.error.code });
                 } catch {
                   if (!disposed) setRepository({ error: "repo-unavailable" });
-                }
-              };
-              void load();
-              return () => { disposed = true; };
-            }, [repositoryRevision]);
-            react.useEffect(() => {
-              let disposed = false;
-              const load = async () => {
-                try {
-                  const answer = operationResult(await memory.legacyRecords());
-                  if (!disposed) {
-                    setLegacyList(answer.ok ? answer.value.records : null);
-                    setLegacyError(answer.ok ? null : answer.error.code);
-                  }
-                } catch {
-                  if (!disposed) { setLegacyList(null); setLegacyError("legacy-unavailable"); }
                 }
               };
               void load();
@@ -223,21 +200,6 @@ window.__ModuleLoader__.load({
                 setPreviewBusy(false);
               }
             };
-            const migrateLegacy = async () => {
-              if (!legacyList || legacyList.length === 0) return;
-              if (!window.confirm(`迁移 ${legacyList.length} 个 legacy 记录？只会补充 front matter，不会修改记忆正文。`)) return;
-              setMigrationBusy(true); setMigrationAction(null);
-              try {
-                const answer = operationResult(await memory.migrateLegacy({ dryRun: false }));
-                if (!answer.ok) return setMigrationAction({ error: answer.error.code });
-                setMigrationAction({ success: answer.value.migratedCount ? `已迁移 ${answer.value.migratedCount} 个 legacy 记录` : "没有需要迁移的 legacy 记录" });
-                setRepositoryRevision((revision) => revision + 1);
-              } catch {
-                setMigrationAction({ error: "legacy-migration-failed" });
-              } finally {
-                setMigrationBusy(false);
-              }
-            };
             const clear = async () => {
               if (stage < 2) return setStage(stage + 1);
               setBusy(true); setState(null);
@@ -297,21 +259,8 @@ window.__ModuleLoader__.load({
                   rollbackState && jsx.jsx("span", { className: rollbackState.error ? "dshmu_status dshmu_status--error" : "dshmu_status dshmu_status--success", children: rollbackState.error ? `回滚失败：${rollbackState.error}` : rollbackState.success }),
                 ] }),
               ] }),
-              ((legacyList === null || legacyList.length > 0) || (previewList === null || previewList.length > 0)) && jsx.jsxs("div", { className: "dshmu_grid", children: [
-                (legacyList === null || legacyList.length > 0) && jsx.jsxs("section", { className: "dshmu_card", "aria-label": "Legacy 记录", children: [
-                  jsx.jsxs("div", { className: "dshmu_cardHeader", children: [
-                    jsx.jsxs("div", { className: "dshmu_cardTitleGroup", children: [
-                      jsx.jsx("span", { className: "dshmu_title", children: "Legacy 记录" }),
-                      jsx.jsx("span", { className: legacyError ? "dshmu_status dshmu_status--error" : "dshmu_status", children: legacyList === null ? legacyError ? `legacy 记录不可用：${legacyError}` : "正在读取 legacy 记录…" : `待迁移 ${legacyList.length} 个 legacy 记录` }),
-                    ] }),
-                  ] }),
-                  legacyList && legacyList.map((record) => jsx.jsx("span", { className: "dshmu_status", children: `${record.path} → ${record.id}` }, record.path)),
-                  jsx.jsxs("div", { className: "dshmu_actions", children: [
-                    jsx.jsx("button", { type: "button", className: "dshmu_button dshmu_button--primary", disabled: !available || migrationBusy || !legacyList || legacyList.length === 0, onClick: migrateLegacy, children: migrationBusy ? "正在迁移…" : "迁移 legacy 记录" }),
-                  ] }),
-                  migrationAction && jsx.jsx("span", { className: migrationAction.error ? "dshmu_status dshmu_status--error" : "dshmu_status dshmu_status--success", children: migrationAction.error ? `迁移失败：${migrationAction.error}` : migrationAction.success }),
-                ] }),
-                (previewList === null || previewList.length > 0) && jsx.jsxs("section", { className: "dshmu_card", "aria-label": "待应用预览", children: [
+              (previewList === null || previewList.length > 0) && jsx.jsxs("div", { className: "dshmu_grid", children: [
+                jsx.jsxs("section", { className: "dshmu_card", "aria-label": "待应用预览", children: [
                   jsx.jsxs("div", { className: "dshmu_cardHeader", children: [
                     jsx.jsxs("div", { className: "dshmu_cardTitleGroup", children: [
                       jsx.jsx("span", { className: "dshmu_title", children: "待应用预览" }),

--- a/tests/test_dsh_memory_e2e_ui.py
+++ b/tests/test_dsh_memory_e2e_ui.py
@@ -5,8 +5,8 @@ Boots a throwaway DSH web profile on an ephemeral port (see
 helpers/dsh-e2e-service.mjs), drives headless Chromium through the Python
 Playwright installation that ships with the machine's browser-acceptance
 tooling, and asserts the rendered panel across desktop/light, dark, and
-narrow viewports, plus the empty-state hiding of the Legacy and preview
-sections on a fresh memory store.
+narrow viewports, plus the empty-state hiding of the preview section on a
+fresh memory store and the absence of the removed Legacy migration UI.
 
 The live memory store, real DSH_HOME, and provider credentials are never
 touched. Exits non-zero on any assertion failure; skipped (exit 0) when
@@ -146,8 +146,9 @@ def main() -> int:
             assert "长期记忆" in txt, "memory section title missing"
             assert "记忆管理" in txt, "memory management card missing"
             assert "最近同步" in txt, "recent sync card missing"
-            # Empty states on a fresh store: Legacy and preview sections hidden.
-            assert "Legacy 记录" not in txt, "Legacy section must be hidden when nothing to migrate"
+            # The Legacy migration UI is intentionally removed; preview remains
+            # hidden when the fresh store has no pending previews.
+            assert "Legacy 记录" not in txt, "Legacy migration UI must remain absent"
             assert "待应用预览" not in txt, "preview section must be hidden when no pending previews"
             # The repository reports healthy (fixture repo), not unavailable.
             match = re.search(r"记忆库[^\n]*", txt)

--- a/tests/test_dsh_memory_ui_settings_row.sh
+++ b/tests/test_dsh_memory_ui_settings_row.sh
@@ -13,15 +13,10 @@ grep -Fq -- 'memory.getSettings()' "$CLIENT"
 grep -Fq -- 'memory.setEnabled({ enabled: value })' "$CLIENT"
 grep -Fq -- 'memory.status()' "$CLIENT"
 grep -Fq -- 'memory.clear({ confirmation: "DELETE_MEMORY" })' "$CLIENT"
-grep -Fq -- 'memory.legacyRecords()' "$CLIENT"
-grep -Fq -- 'memory.migrateLegacy({ dryRun: false })' "$CLIENT"
-grep -Fq -- 'dsh-memory#memory/legacyRecords' "$CLIENT"
-grep -Fq -- 'dsh-memory#memory/migrateLegacy' "$CLIENT"
-grep -Fq -- 'const migrationRequest' "$CLIENT"
-grep -Fq -- 'children: "Legacy 记录"' "$CLIENT"
-grep -Fq -- '待迁移' "$CLIENT"
-grep -Fq -- 'record.path} → ${record.id}' "$CLIENT"
-grep -Fq -- '(legacyList === null || legacyList.length > 0)' "$CLIENT"
+if rg -q -- 'legacyRecords|migrateLegacy|Legacy 记录|待迁移|migrationRequest|migrationBusy|migrationAction' "$CLIENT"; then
+  print -u2 -- 'dsh-memory-ui must not expose the legacy migration UI.'
+  exit 1
+fi
 grep -Fq -- 'className: "dshmu_memory"' "$CLIENT"
 grep -Fq -- 'className: "dshmu_panel dshmu_panel--primary"' "$CLIENT"
 grep -Fq -- 'className: "dshmu_card"' "$CLIENT"


### PR DESCRIPTION
## Summary
- remove the Legacy migration card and controls from settings UI
- retain legacy migration host API and CLI
- update UI tests, E2E assertions, README, and changelog

## Verification
- npm test
- migration API/CLI tests
- Playwright E2E UI checks
- npm pack --dry-run for both workspaces