### PR TITLE
feat: add usage-aware cited memory context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,11 @@ All notable changes to this project are documented here.
 ### Safety
 
 - Context reads are host-owned and read-only with a 20-record limit and a
-  4 KiB per-record body bound.
+  4 KiB per-record body bound; UTF-8 truncation is boundary-safe.
 - Expired records are excluded, citations expose only relative payload paths
   and optional record ids, and no UI or filesystem path selector was added.
+- Usage lock ownership and stale temporary-file cleanup prevent concurrent
+  readers from losing counts or leaking sidecar artifacts into Git.
 
 ## [0.7.0] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ All notable changes to this project are documented here.
 - Removed the Legacy migration card and controls from the settings UI; the
   host API and `dsh-memory-migrate` CLI remain available.
 
+## [0.8.0] - 2026-08-21
+
+### Added
+
+- `memory.context({ query, limit })` returns bounded memory records with stable
+  source citations and deterministic usage-aware ordering.
+- Metadata-only usage feedback is stored atomically in the private
+  `.sync/usage.json` sidecar (`usage_count`, `last_usage`) and never enters
+  payload files or journal records.
+- Existing memory repositories add the sidecar to local Git excludes without
+  modifying tracked files; new repositories include it in `.sync/.gitignore`.
+
+### Safety
+
+- Context reads are host-owned and read-only with a 20-record limit and a
+  4 KiB per-record body bound.
+- Expired records are excluded, citations expose only relative payload paths
+  and optional record ids, and no UI or filesystem path selector was added.
+
 ## [0.7.0] - 2026-08-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -143,6 +143,24 @@ CLI and host API use the same safe transaction path:
   `dsh-memory-migrate --dry-run|--apply` or the host API when migration is
   explicitly needed; the UI never exposes the filesystem root or runs Git.
 
+## v0.8: usage feedback and cited memory context
+
+v0.8 adds a host-owned, read-only context path for future model tools without
+adding settings UI:
+
+- `memory.context({ query, limit })` returns bounded memory bodies with stable
+  source citations (`[source: ... · id: ...]`), while preserving the existing
+  `memory.search()` API.
+- Each context read updates metadata-only usage in `.sync/usage.json` with
+  `usage_count` and `last_usage`; the sidecar is private, atomic, and ignored
+  by Git. Existing repositories also receive a local `.git/info/exclude`
+  entry without changing tracked memory files.
+- Query matches are selected deterministically, then ordered by usage count,
+  recent use, and path. Expired records are never returned.
+
+The context API is deliberately host-only in this release. A later read-only
+tool can expose it to the model without granting filesystem or Git access.
+
 ## v0.7: browser end-to-end tests
 
 v0.7 adds a real browser test suite for the settings UI so the panel's
@@ -164,7 +182,7 @@ behavior is verified, not just snapshot-checked:
 
 ## Compatibility
 
-`v0.7.0` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
+`v0.8.0` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
 tested and locally integrated with a consistently pinned `0.1.0-rc.7` graph:
 
 | Component | Supported version |
@@ -190,14 +208,14 @@ Clone the repository and install its reproducible development/runtime dependenci
 ```zsh
 git clone https://github.com/seriousz158/dsh-memory.git
 cd dsh-memory
-# Use the pinned runtime that this v0.7.0 integration was tested with.
+# Use the pinned runtime that this v0.8.0 integration was tested with.
 npm install --global @deepseek-ai/dsh@0.1.0-rc.7
 dsh --version
 npm ci --ignore-scripts
 ```
 
 This is a source-and-GitHub-Release project. Both workspace packages are
-intentionally marked private, so `v0.7.0` cannot be published to npm by
+intentionally marked private, so `v0.8.0` cannot be published to npm by
 accident.
 
 Install the two local packages into your DSH profile. The installer defaults to

--- a/docs/api.md
+++ b/docs/api.md
@@ -419,7 +419,8 @@ short body snippet:
         "id": "project/codegen",
         "type": "decision",
         "updated_at": "2026-08-10",
-        "snippet": "We chose TypeScript for the codegen pipeline…"
+        "snippet": "We chose TypeScript for the codegen pipeline…",
+        "citation": "[source: handbook/project.md · id: project/codegen]"
       }
     ]
   }
@@ -428,6 +429,42 @@ short body snippet:
 
 `limit` defaults to 20. Failures use `search-invalid-request`,
 `repo-unavailable`, or `search-failed`.
+
+### `memory.context({ query, limit })` (v0.8)
+
+Host-owned read path for a bounded memory context. `query` is optional; when
+omitted, records are ordered by usage feedback. When present, deterministic
+full-text matches are selected first and then ordered by `usage_count`,
+`last_usage`, and path. Expired records are excluded.
+
+```json
+{
+  "ok": true,
+  "value": {
+    "query": "codegen",
+    "count": 1,
+    "records": [
+      {
+        "path": "handbook/project.md",
+        "id": "project/codegen",
+        "type": "decision",
+        "content": "We chose TypeScript for the codegen pipeline.\n",
+        "citation": "[source: handbook/project.md · id: project/codegen]",
+        "usage_count": 3,
+        "last_usage": "2026-08-21T02:00:00.000Z",
+        "score": 5
+      }
+    ]
+  }
+}
+```
+
+`limit` defaults to 10 and is restricted to 1–20. Each returned body is
+bounded to 4 KiB. A successful context read increments metadata-only usage in
+`.sync/usage.json`; the sidecar is atomically written with owner-only
+permissions and is excluded from Git. It contains no memory body, transcript,
+prompt, or credential. Failures use `context-invalid-request`,
+`usage-invalid`, `unsafe-layout`, `repo-unavailable`, or `context-failed`.
 
 ### Front matter schema (v0.4)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -449,6 +449,7 @@ full-text matches are selected first and then ordered by `usage_count`,
         "id": "project/codegen",
         "type": "decision",
         "content": "We chose TypeScript for the codegen pipeline.\n",
+        "truncated": false,
         "citation": "[source: handbook/project.md · id: project/codegen]",
         "usage_count": 3,
         "last_usage": "2026-08-21T02:00:00.000Z",
@@ -463,7 +464,8 @@ full-text matches are selected first and then ordered by `usage_count`,
 bounded to 4 KiB. A successful context read increments metadata-only usage in
 `.sync/usage.json`; the sidecar is atomically written with owner-only
 permissions and is excluded from Git. It contains no memory body, transcript,
-prompt, or credential. Failures use `context-invalid-request`,
+prompt, or credential. `truncated` is true when the body reached the 4 KiB
+limit. Failures use `context-invalid-request`,
 `usage-invalid`, `unsafe-layout`, `repo-unavailable`, or `context-failed`.
 
 ### Front matter schema (v0.4)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,7 +83,7 @@ The sync command does not install DSH. It requires a `dsh` executable on `PATH`,
 The wrapper also discovers a local Homebrew or nvm Node runtime when launchd
 starts with a minimal `PATH`; no interactive shell profile is required.
 
-The v0.7.0 host and UI packages still declare the runtime peer range
+The v0.8.0 host and UI packages still declare the runtime peer range
 `@deepseek-ai/dsh@^0.1.0-rc.6`, so DSH `rc.6` remains peer-compatible. The
 repository's reproducible clean-room and local integration baseline is
 `0.1.0-rc.7`, because the registry's `rc.6` transitive peer graph is not

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-memory-workspace",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-memory-workspace",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "workspaces": [
         "packages/dsh-memory",
         "packages/dsh-memory-ui"
@@ -1131,7 +1131,7 @@
       }
     },
     "packages/dsh-memory": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "engines": {
         "node": ">=22"
@@ -1143,7 +1143,7 @@
       }
     },
     "packages/dsh-memory-ui": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory-workspace",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "Portable DSH long-term memory host and settings UI",
   "workspaces": [

--- a/packages/dsh-memory-ui/package.json
+++ b/packages/dsh-memory-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory-ui",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "Settings UI for DSH local long-term memory",
   "type": "module",

--- a/packages/dsh-memory/lib/index.js
+++ b/packages/dsh-memory/lib/index.js
@@ -20,6 +20,7 @@ import {
 } from "./operation-lock.js";
 import { parseFrontMatter, isExpired, topicKey } from "./memory-metadata.js";
 import { legacyRecordSummary, migratedContent, scanLegacyRecords } from "./legacy-migration.js";
+import { formatCitation, readUsage, recordUsage, sortByUsage, usageMetadata } from "./memory-usage.js";
 import { SyncTransaction } from "./sync-transaction.js";
 
 const execFile = promisify(execFileCallback);
@@ -68,6 +69,13 @@ async function mkdirSafe(path) {
 }
 function hasFrontMatter(content) {
   return content.startsWith("---\n") || content.startsWith("---\r\n");
+}
+function bodyWithoutFrontMatter(content) {
+  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
+}
+function boundedContextBody(content, maxBytes = 4096) {
+  const bytes = Buffer.from(content, "utf8");
+  return bytes.length <= maxBytes ? content : bytes.subarray(0, maxBytes).toString("utf8");
 }
 
 /** Recursively list files under a payload directory as root-relative paths. */
@@ -679,10 +687,54 @@ export class MemoryRepository {
     }
   }
 
+  async collectSearchResults(root, query) {
+    const tokens = query.toLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 0);
+    if (tokens.length === 0) throw memoryError("search-invalid-request");
+    const results = [];
+    const files = await this.payloadFiles(root);
+    for (const file of files) {
+      if (file === "summary.md" || !/\.md$/.test(file)) continue;
+      const content = await readFileSafe(join(root, file), "utf8").catch(() => "");
+      let metadata = null;
+      try { metadata = parseFrontMatter(content, file); } catch { continue; }
+      if (metadata !== null && isExpired(metadata)) continue;
+      const body = bodyWithoutFrontMatter(content);
+      const searchable = [
+        metadata?.id ?? "",
+        metadata?.type ?? "",
+        ...(metadata?.tags ?? []),
+        metadata?.created_by ?? "",
+        metadata?.source_hash ?? "",
+        body,
+      ].join("\n").toLowerCase();
+      let score = 0;
+      for (const token of tokens) {
+        if (searchable.includes(token)) score += 1;
+        if ((metadata?.id ?? "").toLowerCase().includes(token)) score += 3;
+        if ((metadata?.type ?? "").toLowerCase() === token) score += 2;
+        if (body.toLowerCase().includes(token)) score += 1;
+      }
+      if (score > 0) {
+        const lower = body.toLowerCase();
+        const first = lower.indexOf(tokens[0]);
+        const snippet = first === -1 ? body.slice(0, 160) : body.slice(Math.max(0, first - 40), first + 120).replace(/\s+/g, " ").trim();
+        results.push({
+          path: file,
+          score,
+          id: metadata?.id ?? null,
+          type: metadata?.type ?? null,
+          updated_at: metadata?.updated_at ?? null,
+          snippet,
+          citation: formatCitation(file, metadata?.id ?? null),
+        });
+      }
+    }
+    return results.sort((left, right) => right.score - left.score || String(left.path).localeCompare(String(right.path)));
+  }
+
   /**
-   * Local full-text search over the payload records. Tokenizes the query and
-   * scores each record by front matter fields and body text; expired records
-   * are excluded. Returns matches sorted by score with a short snippet.
+   * Local full-text search over payload records. Search itself is read-only;
+   * memory.context() is the model-facing read path that records usage.
    */
   async search(request) {
     if (request?.query === undefined || typeof request.query !== "string" || request.query.trim().length === 0) {
@@ -692,43 +744,74 @@ export class MemoryRepository {
     let root;
     try { root = await this.inspect(); } catch (error) { return failure(error?.memoryCode ?? "repo-unavailable"); }
     try {
-      const tokens = request.query.toLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 0);
-      if (tokens.length === 0) return failure("search-invalid-request");
-      const results = [];
-      const files = await this.payloadFiles(root);
-      for (const file of files) {
-        if (file === "summary.md" || !/\.md$/.test(file)) continue;
-        const content = await readFileSafe(join(root, file), "utf8").catch(() => "");
-        let metadata = null;
-        try { metadata = parseFrontMatter(content, file); } catch { continue; }
-        if (metadata !== null && isExpired(metadata)) continue;
-        const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
-        const searchable = [
-          metadata?.id ?? "",
-          metadata?.type ?? "",
-          ...(metadata?.tags ?? []),
-          metadata?.created_by ?? "",
-          metadata?.source_hash ?? "",
-          body,
-        ].join("\n").toLowerCase();
-        let score = 0;
-        for (const token of tokens) {
-          if (searchable.includes(token)) score += 1;
-          if ((metadata?.id ?? "").toLowerCase().includes(token)) score += 3;
-          if ((metadata?.type ?? "").toLowerCase() === token) score += 2;
-          if (body.toLowerCase().includes(token)) score += 1;
-        }
-        if (score > 0) {
-          const lower = body.toLowerCase();
-          const first = lower.indexOf(tokens[0]);
-          const snippet = first === -1 ? body.slice(0, 160) : body.slice(Math.max(0, first - 40), first + 120).replace(/\s+/g, " ").trim();
-          results.push({ path: file, score, id: metadata?.id ?? null, type: metadata?.type ?? null, updated_at: metadata?.updated_at ?? null, snippet });
-        }
-      }
-      results.sort((left, right) => right.score - left.score || String(left.path).localeCompare(String(right.path)));
+      const results = await this.collectSearchResults(root, request.query);
       return success({ query: request.query, count: results.length, results: results.slice(0, limit) });
     } catch (error) {
       return failure(error?.memoryCode ?? "search-failed");
+    }
+  }
+
+  /**
+   * Read a bounded memory context and record metadata-only usage feedback.
+   * Query matching chooses relevant candidates; usage order then determines
+   * the order in which selected records are injected into a future tool path.
+   */
+  async context(request = {}) {
+    const hasQuery = request?.query !== undefined;
+    if (hasQuery && (typeof request.query !== "string" || request.query.trim().length === 0)) return failure("context-invalid-request");
+    const limit = request?.limit === undefined ? 10 : request.limit;
+    if (!Number.isInteger(limit) || limit < 1 || limit > 20) return failure("context-invalid-request");
+    let root;
+    try { root = await this.inspect(); } catch (error) { return failure(error?.memoryCode ?? "repo-unavailable"); }
+    try {
+      const usage = await readUsage(root);
+      let candidates;
+      if (hasQuery) {
+        candidates = (await this.collectSearchResults(root, request.query)).slice(0, limit);
+      } else {
+        candidates = [];
+        for (const file of await this.payloadFiles(root)) {
+          if (file === "summary.md" || !/\.md$/.test(file)) continue;
+          const content = await readFileSafe(join(root, file), "utf8").catch(() => "");
+          let metadata = null;
+          try { metadata = parseFrontMatter(content, file); } catch { continue; }
+          if (metadata !== null && isExpired(metadata)) continue;
+          candidates.push({
+            path: file,
+            score: 0,
+            id: metadata?.id ?? null,
+            type: metadata?.type ?? null,
+            updated_at: metadata?.updated_at ?? null,
+            citation: formatCitation(file, metadata?.id ?? null),
+          });
+        }
+        candidates = sortByUsage(candidates, usage).slice(0, limit);
+      }
+      const ordered = sortByUsage(candidates, usage);
+      const updatedUsage = await recordUsage(root, ordered.map((entry) => entry.path));
+      const records = [];
+      for (const entry of ordered) {
+        const content = await readFileSafe(join(root, entry.path), "utf8").catch(() => "");
+        const body = boundedContextBody(bodyWithoutFrontMatter(content));
+        const metadata = usageMetadata(entry.path, updatedUsage);
+        records.push({
+          path: entry.path,
+          id: entry.id ?? null,
+          type: entry.type ?? null,
+          content: body,
+          citation: entry.citation ?? formatCitation(entry.path, entry.id ?? null),
+          usage_count: metadata.usage_count,
+          last_usage: metadata.last_usage || null,
+          ...(hasQuery ? { score: entry.score } : {}),
+        });
+      }
+      return success({
+        query: hasQuery ? request.query : null,
+        count: records.length,
+        records,
+      });
+    } catch (error) {
+      return failure(error?.memoryCode ?? "context-failed");
     }
   }
 
@@ -954,6 +1037,7 @@ export class MemoryService extends TypertRemoteService {
   async applyPreview(request) { return await this.repository.applyPreview(request); }
   async discardPreview(request) { return await this.repository.discardPreview(request); }
   async search(request) { return await this.repository.search(request); }
+  async context(request) { return await this.repository.context(request); }
 }
 decorate(MemoryService, "getSettings", Remote("getSettings"));
 decorate(MemoryService, "setEnabled", Remote("setEnabled"));
@@ -968,6 +1052,7 @@ decorate(MemoryService, "previews", Remote("previews"));
 decorate(MemoryService, "applyPreview", Remote("applyPreview"));
 decorate(MemoryService, "discardPreview", Remote("discardPreview"));
 decorate(MemoryService, "search", Remote("search"));
+decorate(MemoryService, "context", Remote("context"));
 
 export function apply(ctx, entry) {
   const settings = new MemorySettingsBridge();

--- a/packages/dsh-memory/lib/index.js
+++ b/packages/dsh-memory/lib/index.js
@@ -75,7 +75,12 @@ function bodyWithoutFrontMatter(content) {
 }
 function boundedContextBody(content, maxBytes = 4096) {
   const bytes = Buffer.from(content, "utf8");
-  return bytes.length <= maxBytes ? content : bytes.subarray(0, maxBytes).toString("utf8");
+  if (bytes.length <= maxBytes) return { content, truncated: false };
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  for (let end = maxBytes; end > 0; end -= 1) {
+    try { return { content: decoder.decode(bytes.subarray(0, end)), truncated: true }; } catch {}
+  }
+  return { content: "", truncated: true };
 }
 
 /** Recursively list files under a payload directory as root-relative paths. */
@@ -767,7 +772,7 @@ export class MemoryRepository {
       const usage = await readUsage(root);
       let candidates;
       if (hasQuery) {
-        candidates = (await this.collectSearchResults(root, request.query)).slice(0, limit);
+        candidates = sortByUsage(await this.collectSearchResults(root, request.query), usage).slice(0, limit);
       } else {
         candidates = [];
         for (const file of await this.payloadFiles(root)) {
@@ -798,7 +803,8 @@ export class MemoryRepository {
           path: entry.path,
           id: entry.id ?? null,
           type: entry.type ?? null,
-          content: body,
+          content: body.content,
+          truncated: body.truncated,
           citation: entry.citation ?? formatCitation(entry.path, entry.id ?? null),
           usage_count: metadata.usage_count,
           last_usage: metadata.last_usage || null,

--- a/packages/dsh-memory/lib/memory-usage.js
+++ b/packages/dsh-memory/lib/memory-usage.js
@@ -1,0 +1,193 @@
+import { chmod, lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+
+export const USAGE_FILE = ".sync/usage.json";
+export const USAGE_SCHEMA_VERSION = 1;
+const MAX_USAGE_BYTES = 1024 * 1024;
+const USAGE_LOCK = ".sync/usage.lock";
+const USAGE_LOCK_TIMEOUT_MS = 30_000;
+const PAYLOAD_ROOTS = new Set(["handbook", "rollouts", "archive"]);
+const usageQueues = new Map();
+
+function usageError(code) {
+  return Object.assign(new Error(`memory usage state is invalid: ${code}`), { memoryCode: code });
+}
+
+function isSafeUsagePath(path) {
+  if (typeof path !== "string" || path.length === 0 || path.startsWith("/")) return false;
+  const parts = path.split("/");
+  return parts.length >= 2
+    && PAYLOAD_ROOTS.has(parts[0])
+    && parts.every((part) => part.length > 0 && part !== "." && part !== "..")
+    && path.endsWith(".md");
+}
+
+function emptyUsage() {
+  return { schema_version: USAGE_SCHEMA_VERSION, records: {} };
+}
+
+function validateUsage(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) throw usageError("usage-invalid");
+  if (value.schema_version !== USAGE_SCHEMA_VERSION) throw usageError("usage-invalid");
+  if (value.records === null || typeof value.records !== "object" || Array.isArray(value.records)) throw usageError("usage-invalid");
+  const records = {};
+  for (const [path, entry] of Object.entries(value.records)) {
+    if (!isSafeUsagePath(path) || entry === null || typeof entry !== "object" || Array.isArray(entry)
+      || !Number.isInteger(entry.usage_count) || entry.usage_count < 0 || entry.usage_count > Number.MAX_SAFE_INTEGER
+      || (entry.last_usage !== null && typeof entry.last_usage !== "string")) {
+      throw usageError("usage-invalid");
+    }
+    records[path] = {
+      usage_count: entry.usage_count,
+      last_usage: entry.last_usage,
+    };
+  }
+  return { schema_version: USAGE_SCHEMA_VERSION, records };
+}
+
+async function ensurePrivateDirectory(path) {
+  const stat = await lstat(path).catch((error) => {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  });
+  if (stat !== null && (stat.isSymbolicLink() || !stat.isDirectory())) throw usageError("unsafe-layout");
+  if (stat === null) await mkdir(path, { recursive: true, mode: 0o700 });
+  await chmod(path, 0o700);
+}
+
+async function ensureGitExclude(root) {
+  const gitRoot = join(root, ".git");
+  const gitStat = await lstat(gitRoot).catch(() => null);
+  if (gitStat === null || gitStat.isSymbolicLink() || !gitStat.isDirectory()) return;
+  const infoRoot = join(gitRoot, "info");
+  await ensurePrivateDirectory(infoRoot);
+  const exclude = join(infoRoot, "exclude");
+  const current = await readFile(exclude, "utf8").catch((error) => {
+    if (error?.code === "ENOENT") return "";
+    throw error;
+  });
+  const lines = current.split(/\r?\n/);
+  const missing = [USAGE_FILE, USAGE_LOCK].filter((entry) => !lines.includes(entry));
+  if (missing.length === 0) return;
+  const suffix = current.length === 0 || current.endsWith("\n") ? "" : "\n";
+  await writeFile(exclude, `${current}${suffix}${missing.join("\n")}\n`, { mode: 0o600 });
+  await chmod(exclude, 0o600);
+}
+
+async function acquireUsageLock(syncRoot) {
+  const lockPath = join(syncRoot, "usage.lock");
+  for (let attempt = 0; attempt < 400; attempt += 1) {
+    try {
+      await mkdir(lockPath, { mode: 0o700 });
+      return lockPath;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      const lockStat = await lstat(lockPath).catch(() => null);
+      if (lockStat === null) continue;
+      if (Date.now() - lockStat.mtimeMs > USAGE_LOCK_TIMEOUT_MS) {
+        await rm(lockPath, { recursive: true, force: true });
+        continue;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  }
+  throw usageError("usage-busy");
+}
+
+async function withUsageLock(root, callback) {
+  const previous = usageQueues.get(root) ?? Promise.resolve();
+  let releaseQueue;
+  const queued = new Promise((resolve) => { releaseQueue = resolve; });
+  usageQueues.set(root, queued);
+  await previous.catch(() => {});
+  const syncRoot = join(root, ".sync");
+  let lockPath;
+  try {
+    await ensurePrivateDirectory(syncRoot);
+    lockPath = await acquireUsageLock(syncRoot);
+    return await callback();
+  } finally {
+    if (lockPath !== undefined) await rm(lockPath, { recursive: true, force: true }).catch(() => {});
+    releaseQueue();
+    if (usageQueues.get(root) === queued) usageQueues.delete(root);
+  }
+}
+
+export async function readUsage(root) {
+  const usagePath = join(root, USAGE_FILE);
+  const stat = await lstat(usagePath).catch((error) => {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  });
+  if (stat === null) return emptyUsage();
+  if (stat.isSymbolicLink() || !stat.isFile() || stat.size > MAX_USAGE_BYTES) throw usageError("unsafe-layout");
+  const raw = await readFile(usagePath, "utf8");
+  try {
+    return validateUsage(JSON.parse(raw));
+  } catch (error) {
+    if (error?.memoryCode) throw error;
+    throw usageError("usage-invalid");
+  }
+}
+
+export async function recordUsage(root, paths, now = new Date()) {
+  if (!Array.isArray(paths) || paths.some((path) => !isSafeUsagePath(path))) throw usageError("usage-invalid");
+  const uniquePaths = [...new Set(paths)];
+  if (uniquePaths.length === 0) return await readUsage(root);
+  const date = now instanceof Date ? now : new Date(now);
+  if (Number.isNaN(date.getTime())) throw usageError("usage-invalid");
+  return await withUsageLock(root, async () => {
+    const syncRoot = join(root, ".sync");
+    const usage = await readUsage(root);
+    const timestamp = date.toISOString();
+    for (const path of uniquePaths) {
+      const previous = usage.records[path] ?? { usage_count: 0, last_usage: null };
+      usage.records[path] = {
+        usage_count: previous.usage_count + 1,
+        last_usage: timestamp,
+      };
+    }
+    const usagePath = join(root, USAGE_FILE);
+    const temporary = join(syncRoot, `.usage.${process.pid}.${randomUUID()}.tmp`);
+    await writeFile(temporary, `${JSON.stringify(usage)}\n`, { mode: 0o600, flag: "wx" });
+    try {
+      await chmod(temporary, 0o600);
+      await rename(temporary, usagePath);
+      await chmod(usagePath, 0o600);
+      await ensureGitExclude(root);
+    } catch (error) {
+      await rename(temporary, usagePath).catch(() => {});
+      throw error;
+    }
+    return usage;
+  });
+}
+
+function usageOf(entry, usage) {
+  const value = usage?.records?.[entry.path];
+  return {
+    usage_count: Number.isInteger(value?.usage_count) ? value.usage_count : 0,
+    last_usage: typeof value?.last_usage === "string" ? value.last_usage : "",
+  };
+}
+
+export function sortByUsage(entries, usage) {
+  return [...entries].sort((left, right) => {
+    const a = usageOf(left, usage);
+    const b = usageOf(right, usage);
+    return b.usage_count - a.usage_count
+      || b.last_usage.localeCompare(a.last_usage)
+      || String(left.path).localeCompare(String(right.path));
+  });
+}
+
+export function usageMetadata(path, usage) {
+  return usageOf({ path }, usage);
+}
+
+export function formatCitation(path, id = null) {
+  return id === null || id === undefined
+    ? `[source: ${path}]`
+    : `[source: ${path} · id: ${id}]`;
+}

--- a/packages/dsh-memory/lib/memory-usage.js
+++ b/packages/dsh-memory/lib/memory-usage.js
@@ -1,4 +1,4 @@
-import { chmod, lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 
@@ -6,6 +6,7 @@ export const USAGE_FILE = ".sync/usage.json";
 export const USAGE_SCHEMA_VERSION = 1;
 const MAX_USAGE_BYTES = 1024 * 1024;
 const USAGE_LOCK = ".sync/usage.lock";
+const USAGE_TEMP = ".sync/.usage.*.tmp";
 const USAGE_LOCK_TIMEOUT_MS = 30_000;
 const PAYLOAD_ROOTS = new Set(["handbook", "rollouts", "archive"]);
 const usageQueues = new Map();
@@ -63,12 +64,17 @@ async function ensureGitExclude(root) {
   const infoRoot = join(gitRoot, "info");
   await ensurePrivateDirectory(infoRoot);
   const exclude = join(infoRoot, "exclude");
+  const excludeStat = await lstat(exclude).catch((error) => {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  });
+  if (excludeStat !== null && (excludeStat.isSymbolicLink() || !excludeStat.isFile())) throw usageError("unsafe-layout");
   const current = await readFile(exclude, "utf8").catch((error) => {
     if (error?.code === "ENOENT") return "";
     throw error;
   });
   const lines = current.split(/\r?\n/);
-  const missing = [USAGE_FILE, USAGE_LOCK].filter((entry) => !lines.includes(entry));
+  const missing = [USAGE_FILE, USAGE_LOCK, USAGE_TEMP].filter((entry) => !lines.includes(entry));
   if (missing.length === 0) return;
   const suffix = current.length === 0 || current.endsWith("\n") ? "" : "\n";
   await writeFile(exclude, `${current}${suffix}${missing.join("\n")}\n`, { mode: 0o600 });
@@ -80,12 +86,24 @@ async function acquireUsageLock(syncRoot) {
   for (let attempt = 0; attempt < 400; attempt += 1) {
     try {
       await mkdir(lockPath, { mode: 0o700 });
+      await writeFile(join(lockPath, "owner.json"), JSON.stringify({ pid: process.pid, started_at: new Date().toISOString() }) + "\n", { mode: 0o600 });
       return lockPath;
     } catch (error) {
       if (error?.code !== "EEXIST") throw error;
       const lockStat = await lstat(lockPath).catch(() => null);
       if (lockStat === null) continue;
-      if (Date.now() - lockStat.mtimeMs > USAGE_LOCK_TIMEOUT_MS) {
+      const owner = await readFile(join(lockPath, "owner.json"), "utf8").then((raw) => JSON.parse(raw)).catch(() => null);
+      const ownerPid = Number.isInteger(owner?.pid) ? owner.pid : null;
+      let ownerAlive = false;
+      if (ownerPid !== null && ownerPid > 0) {
+        try {
+          process.kill(ownerPid, 0);
+          ownerAlive = true;
+        } catch (ownerError) {
+          ownerAlive = ownerError?.code === "EPERM";
+        }
+      }
+      if (!ownerAlive && Date.now() - lockStat.mtimeMs > USAGE_LOCK_TIMEOUT_MS) {
         await rm(lockPath, { recursive: true, force: true });
         continue;
       }
@@ -93,6 +111,14 @@ async function acquireUsageLock(syncRoot) {
     }
   }
   throw usageError("usage-busy");
+}
+
+async function cleanupUsageTemps(syncRoot) {
+  const entries = await readdir(syncRoot, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (!entry.name.startsWith(".usage.") || !entry.name.endsWith(".tmp")) continue;
+    await rm(join(syncRoot, entry.name), { recursive: true, force: true }).catch(() => {});
+  }
 }
 
 async function withUsageLock(root, callback) {
@@ -106,6 +132,7 @@ async function withUsageLock(root, callback) {
   try {
     await ensurePrivateDirectory(syncRoot);
     lockPath = await acquireUsageLock(syncRoot);
+    await cleanupUsageTemps(syncRoot);
     return await callback();
   } finally {
     if (lockPath !== undefined) await rm(lockPath, { recursive: true, force: true }).catch(() => {});

--- a/packages/dsh-memory/package.json
+++ b/packages/dsh-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "Automatic local long-term memory for DSH",
   "type": "module",

--- a/packages/dsh-memory/templates/.sync/.gitignore
+++ b/packages/dsh-memory/templates/.sync/.gitignore
@@ -1,3 +1,5 @@
 operation.lock
 active-run.json
 previews/
+usage.json
+usage.lock/

--- a/packages/dsh-memory/templates/.sync/.gitignore
+++ b/packages/dsh-memory/templates/.sync/.gitignore
@@ -3,3 +3,4 @@ active-run.json
 previews/
 usage.json
 usage.lock/
+.usage.*.tmp

--- a/packages/dsh-memory/templates/README.md
+++ b/packages/dsh-memory/templates/README.md
@@ -10,6 +10,7 @@
 - `archive/`：已过时或被替代的条目。
 - `scripts/filter_session.py`：将 DSH 会话日志转为精简、脱敏的转录。
 - `.last-sync`：增量同步水位；首次创建时不回溯旧会话。
+- `.sync/usage.json`：本地读取使用计数与最近使用时间；只存元数据，不进 Git。
 
 ## 规则
 

--- a/tests/run-memory-tests.sh
+++ b/tests/run-memory-tests.sh
@@ -13,6 +13,8 @@ node tests/test_dsh_memory_migration_api.mjs
 node tests/test_dsh_memory_sync_transaction.mjs
 node tests/test_dsh_memory_operation_lock.mjs
 node tests/test_dsh_memory_metadata.mjs
+node tests/test_dsh_memory_usage.mjs
+node tests/test_dsh_memory_context.mjs
 node tests/test_dsh_memory_paths.mjs
 node tests/test_dsh_memory_preview.mjs
 node tests/test_dsh_memory_redaction.mjs

--- a/tests/test_dsh_memory_context.mjs
+++ b/tests/test_dsh_memory_context.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { MemoryRepository } from "../packages/dsh-memory/lib/index.js";
+
+const execFile = promisify(execFileCallback);
+const git = async (root, args) => await execFile("/usr/bin/git", ["-C", root, ...args], { encoding: "utf8" });
+const root = await mkdtemp(join(tmpdir(), "dsh-memory-context-"));
+await git(root, ["init"]);
+await git(root, ["config", "user.name", "DSH Memory Context Test"]);
+await git(root, ["config", "user.email", "dsh-memory-context@example.invalid"]);
+for (const dir of ["handbook", "rollouts", "archive", ".sync"]) await mkdir(join(root, dir));
+await writeFile(join(root, "summary.md"), "navigation\n");
+await writeFile(join(root, ".last-sync"), "0\n");
+await writeFile(join(root, ".sync", ".gitignore"), "usage.json\n", { mode: 0o600 });
+await writeFile(join(root, "handbook", "alpha.md"), `---
+schema_version: 1
+id: project/alpha
+type: decision
+---
+Shared architecture decision alpha.
+`);
+await writeFile(join(root, "rollouts", "beta.md"), `---
+schema_version: 1
+id: project/beta
+type: decision
+---
+Shared architecture decision beta.
+`);
+await writeFile(join(root, "archive", "legacy.md"), "Shared legacy note.\n");
+await git(root, ["add", "."]);
+await git(root, ["commit", "-m", "context fixture"]);
+
+const service = new MemoryRepository({ root, __testOnly: true });
+const initial = await service.context();
+assert.equal(initial.ok, true);
+assert.deepEqual(initial.value.records.map((record) => record.path), [
+  "archive/legacy.md",
+  "handbook/alpha.md",
+  "rollouts/beta.md",
+]);
+assert.equal(initial.value.records[1].content, "Shared architecture decision alpha.\n");
+assert.equal(initial.value.records[1].citation, "[source: handbook/alpha.md · id: project/alpha]");
+assert.equal(initial.value.records[1].usage_count, 1);
+
+const searched = await service.context({ query: "architecture", limit: 2 });
+assert.equal(searched.ok, true);
+assert.deepEqual(searched.value.records.map((record) => record.path), [
+  "handbook/alpha.md",
+  "rollouts/beta.md",
+]);
+assert.equal(searched.value.records[0].usage_count, 2);
+assert.equal(searched.value.records[1].usage_count, 2);
+assert.equal(searched.value.records[0].score > 0, true);
+
+const invalidQuery = await service.context({ query: "" });
+assert.deepEqual(invalidQuery, { ok: false, error: { code: "context-invalid-request" } });
+const invalidLimit = await service.context({ limit: 21 });
+assert.deepEqual(invalidLimit, { ok: false, error: { code: "context-invalid-request" } });
+
+const status = (await git(root, ["status", "--porcelain"])).stdout;
+assert.equal(status, "");
+assert.match(await readFile(join(root, ".sync", "usage.json"), "utf8"), /usage_count/);
+assert.match(await readFile(join(root, ".git", "info", "exclude"), "utf8"), /\.sync\/usage\.json/);
+
+console.log("dsh-memory context tests passed");

--- a/tests/test_dsh_memory_context.mjs
+++ b/tests/test_dsh_memory_context.mjs
@@ -15,11 +15,13 @@ await git(root, ["config", "user.email", "dsh-memory-context@example.invalid"]);
 for (const dir of ["handbook", "rollouts", "archive", ".sync"]) await mkdir(join(root, dir));
 await writeFile(join(root, "summary.md"), "navigation\n");
 await writeFile(join(root, ".last-sync"), "0\n");
-await writeFile(join(root, ".sync", ".gitignore"), "usage.json\n", { mode: 0o600 });
+await writeFile(join(root, ".sync", ".gitignore"), "usage.json\nusage.lock/\n.usage.*.tmp\n", { mode: 0o600 });
 await writeFile(join(root, "handbook", "alpha.md"), `---
 schema_version: 1
 id: project/alpha
 type: decision
+tags:
+  - architecture
 ---
 Shared architecture decision alpha.
 `);
@@ -27,10 +29,14 @@ await writeFile(join(root, "rollouts", "beta.md"), `---
 schema_version: 1
 id: project/beta
 type: decision
+tags:
+  - architecture
 ---
 Shared architecture decision beta.
 `);
+await writeFile(join(root, "archive", "gamma.md"), "gamma architecture\n");
 await writeFile(join(root, "archive", "legacy.md"), "Shared legacy note.\n");
+await writeFile(join(root, "archive", "long.md"), "长".repeat(2500));
 await git(root, ["add", "."]);
 await git(root, ["commit", "-m", "context fixture"]);
 
@@ -38,21 +44,30 @@ const service = new MemoryRepository({ root, __testOnly: true });
 const initial = await service.context();
 assert.equal(initial.ok, true);
 assert.deepEqual(initial.value.records.map((record) => record.path), [
+  "archive/gamma.md",
   "archive/legacy.md",
+  "archive/long.md",
   "handbook/alpha.md",
   "rollouts/beta.md",
 ]);
-assert.equal(initial.value.records[1].content, "Shared architecture decision alpha.\n");
-assert.equal(initial.value.records[1].citation, "[source: handbook/alpha.md · id: project/alpha]");
-assert.equal(initial.value.records[1].usage_count, 1);
+const alpha = initial.value.records.find((record) => record.path === "handbook/alpha.md");
+assert.equal(alpha.content, "Shared architecture decision alpha.\n");
+assert.equal(alpha.citation, "[source: handbook/alpha.md · id: project/alpha]");
+assert.equal(alpha.usage_count, 1);
+const long = initial.value.records.find((record) => record.path === "archive/long.md");
+assert.equal(long.truncated, true);
+assert.equal(Buffer.byteLength(long.content, "utf8") <= 4096, true);
+assert.doesNotMatch(long.content, /�/);
+
+for (let index = 0; index < 3; index += 1) await service.context({ query: "gamma", limit: 1 });
 
 const searched = await service.context({ query: "architecture", limit: 2 });
 assert.equal(searched.ok, true);
 assert.deepEqual(searched.value.records.map((record) => record.path), [
+  "archive/gamma.md",
   "handbook/alpha.md",
-  "rollouts/beta.md",
 ]);
-assert.equal(searched.value.records[0].usage_count, 2);
+assert.equal(searched.value.records[0].usage_count, 5);
 assert.equal(searched.value.records[1].usage_count, 2);
 assert.equal(searched.value.records[0].score > 0, true);
 

--- a/tests/test_dsh_memory_paths.mjs
+++ b/tests/test_dsh_memory_paths.mjs
@@ -26,6 +26,10 @@ await cp(
   join(fixture, "dsh-memory", "lib", "memory-tree.js"),
 );
 await cp(
+  join(project, "packages/dsh-memory/lib/memory-usage.js"),
+  join(fixture, "dsh-memory", "lib", "memory-usage.js"),
+);
+await cp(
   join(project, "packages/dsh-memory/lib/legacy-migration.js"),
   join(fixture, "dsh-memory", "lib", "legacy-migration.js"),
 );

--- a/tests/test_dsh_memory_repository.mjs
+++ b/tests/test_dsh_memory_repository.mjs
@@ -79,6 +79,7 @@ We chose TypeScript for the codegen pipeline.\n`);
   assert.equal(hit.value.count, 1);
   assert.equal(hit.value.results[0].path, "handbook/project.md");
   assert.equal(hit.value.results[0].id, "project/codegen");
+  assert.equal(hit.value.results[0].citation, "[source: handbook/project.md · id: project/codegen]");
   assert.ok(hit.value.results[0].score >= 1);
   const miss = await service.search({ query: "nonexistent-term" });
   assert.equal(miss.ok, true);

--- a/tests/test_dsh_memory_runtime.sh
+++ b/tests/test_dsh_memory_runtime.sh
@@ -13,6 +13,7 @@ grep -Fq -- 'ctx.inject(["systemPrompt"]' "$HOST"
 grep -Fq -- 'new MemoryService(ctx, { settings })' "$HOST"
 grep -Fq -- 'Remote("status")' "$HOST"
 grep -Fq -- 'Remote("clear")' "$HOST"
+grep -Fq -- 'Remote("context")' "$HOST"
 grep -Fq -- 'safe-clear.py' "$HOST"
 grep -Fq -- 'safeClear(root, "stage")' "$HOST"
 grep -Fq -- 'alternateIndex' "$HOST"
@@ -30,7 +31,7 @@ fi
 node -e '
 const p=require(process.argv[1]);
 const peers=["@deepseek-ai/dsh-settings","@deepseek-ai/dsh-typert-protocol","@deepseek-ai/schemastery"];
-if (p.private !== true || p.version !== "0.7.0" || p.exports?.["."] !== "./lib/index.js" || p.type !== "module" || peers.some((name) => !p.peerDependencies?.[name])) process.exit(1);
+if (p.private !== true || p.version !== "0.8.0" || p.exports?.["."] !== "./lib/index.js" || p.type !== "module" || peers.some((name) => !p.peerDependencies?.[name])) process.exit(1);
 ' "$PACKAGE"
 node --check "$HOST"
 python3 -c 'import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text())' "$PROJECT_DIR/packages/dsh-memory/lib/safe-clear.py"

--- a/tests/test_dsh_memory_ui_settings_row.sh
+++ b/tests/test_dsh_memory_ui_settings_row.sh
@@ -34,7 +34,7 @@ fi
 node -e '
 const p=require(process.argv[1]);
 const peers=["@deepseek-ai/dsh-api-remotes","@deepseek-ai/dsh-client-connection","@deepseek-ai/dsh-client-runtime","@deepseek-ai/dsh-client-ui-settings","react"];
-if (p.private !== true || p.version !== "0.7.0" || p.exports?.["./client"] !== "./lib/client.js" || p.main !== "./lib/index.js" || peers.some((name) => !p.peerDependencies?.[name])) process.exit(1);
+if (p.private !== true || p.version !== "0.8.0" || p.exports?.["./client"] !== "./lib/client.js" || p.main !== "./lib/index.js" || peers.some((name) => !p.peerDependencies?.[name])) process.exit(1);
 ' "$PACKAGE"
 node --check "$CLIENT"
 print "dsh-memory UI settings row tests passed"

--- a/tests/test_dsh_memory_usage.mjs
+++ b/tests/test_dsh_memory_usage.mjs
@@ -17,9 +17,11 @@ const execFile = promisify(execFileCallback);
 const root = await mkdtemp(join(tmpdir(), "dsh-memory-usage-"));
 await mkdir(join(root, ".sync"), { mode: 0o700 });
 await writeFile(join(root, ".sync", ".gitignore"), "usage.json\n", { mode: 0o600 });
+await mkdir(join(root, ".sync", ".usage.dead.tmp"), { mode: 0o700 });
 
 const first = new Date("2026-08-21T01:00:00.000Z");
 await recordUsage(root, ["handbook/alpha.md", "rollouts/beta.md"], first);
+await assert.rejects(() => stat(join(root, ".sync", ".usage.dead.tmp")), (error) => error?.code === "ENOENT");
 await recordUsage(root, ["handbook/alpha.md"], new Date("2026-08-21T02:00:00.000Z"));
 
 const usage = await readUsage(root);

--- a/tests/test_dsh_memory_usage.mjs
+++ b/tests/test_dsh_memory_usage.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  USAGE_FILE,
+  formatCitation,
+  readUsage,
+  recordUsage,
+  sortByUsage,
+} from "../packages/dsh-memory/lib/memory-usage.js";
+
+const root = await mkdtemp(join(tmpdir(), "dsh-memory-usage-"));
+await mkdir(join(root, ".sync"), { mode: 0o700 });
+await writeFile(join(root, ".sync", ".gitignore"), "usage.json\n", { mode: 0o600 });
+
+const first = new Date("2026-08-21T01:00:00.000Z");
+await recordUsage(root, ["handbook/alpha.md", "rollouts/beta.md"], first);
+await recordUsage(root, ["handbook/alpha.md"], new Date("2026-08-21T02:00:00.000Z"));
+
+const usage = await readUsage(root);
+assert.equal(usage.schema_version, 1);
+assert.deepEqual(usage.records["handbook/alpha.md"], {
+  usage_count: 2,
+  last_usage: "2026-08-21T02:00:00.000Z",
+});
+assert.deepEqual(usage.records["rollouts/beta.md"], {
+  usage_count: 1,
+  last_usage: "2026-08-21T01:00:00.000Z",
+});
+
+const usagePath = join(root, USAGE_FILE);
+assert.equal((await stat(usagePath)).mode & 0o777, 0o600);
+assert.doesNotMatch(await readFile(usagePath, "utf8"), /正文|transcript|prompt|credential/);
+
+const sorted = sortByUsage([
+  { path: "rollouts/beta.md" },
+  { path: "handbook/alpha.md" },
+  { path: "archive/unused.md" },
+], usage);
+assert.deepEqual(sorted.map((entry) => entry.path), [
+  "handbook/alpha.md",
+  "rollouts/beta.md",
+  "archive/unused.md",
+]);
+
+assert.equal(formatCitation("handbook/alpha.md", "project/alpha"), "[source: handbook/alpha.md · id: project/alpha]");
+assert.equal(formatCitation("rollouts/beta.md", null), "[source: rollouts/beta.md]");
+
+await chmod(usagePath, 0o644);
+await recordUsage(root, ["archive/unused.md"], new Date("2026-08-21T03:00:00.000Z"));
+assert.equal((await stat(usagePath)).mode & 0o777, 0o600);
+
+await Promise.all(Array.from({ length: 8 }, (_, index) => recordUsage(
+  root,
+  ["archive/unused.md"],
+  new Date(`2026-08-21T03:00:0${index}.000Z`),
+)));
+assert.equal((await readUsage(root)).records["archive/unused.md"].usage_count, 9);
+
+await writeFile(usagePath, JSON.stringify({ schema_version: 1, records: { "../escape.md": { usage_count: 1, last_usage: null } } }));
+await assert.rejects(() => readUsage(root), (error) => error?.memoryCode === "usage-invalid");
+
+console.log("dsh-memory usage tests passed");

--- a/tests/test_dsh_memory_usage.mjs
+++ b/tests/test_dsh_memory_usage.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
+import { execFile as execFileCallback } from "node:child_process";
 import { chmod, mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import {
   USAGE_FILE,
   formatCitation,
@@ -10,6 +13,7 @@ import {
   sortByUsage,
 } from "../packages/dsh-memory/lib/memory-usage.js";
 
+const execFile = promisify(execFileCallback);
 const root = await mkdtemp(join(tmpdir(), "dsh-memory-usage-"));
 await mkdir(join(root, ".sync"), { mode: 0o700 });
 await writeFile(join(root, ".sync", ".gitignore"), "usage.json\n", { mode: 0o600 });
@@ -57,6 +61,11 @@ await Promise.all(Array.from({ length: 8 }, (_, index) => recordUsage(
   new Date(`2026-08-21T03:00:0${index}.000Z`),
 )));
 assert.equal((await readUsage(root)).records["archive/unused.md"].usage_count, 9);
+
+const usageModule = pathToFileURL(join(process.cwd(), "packages/dsh-memory/lib/memory-usage.js")).href;
+const childProgram = `import { recordUsage } from ${JSON.stringify(usageModule)}; await recordUsage(${JSON.stringify(root)}, ["handbook/alpha.md"]);`;
+await Promise.all(Array.from({ length: 4 }, () => execFile(process.execPath, ["--input-type=module", "--eval", childProgram], { encoding: "utf8" })));
+assert.equal((await readUsage(root)).records["handbook/alpha.md"].usage_count, 6);
 
 await writeFile(usagePath, JSON.stringify({ schema_version: 1, records: { "../escape.md": { usage_count: 1, last_usage: null } } }));
 await assert.rejects(() => readUsage(root), (error) => error?.memoryCode === "usage-invalid");

--- a/tools/public-tree-check.mjs
+++ b/tools/public-tree-check.mjs
@@ -54,6 +54,7 @@ const allowed = new Set([
   "packages/dsh-memory/lib/index.js",
   "packages/dsh-memory/lib/legacy-migration.js",
   "packages/dsh-memory/lib/memory-metadata.js",
+  "packages/dsh-memory/lib/memory-usage.js",
   "packages/dsh-memory/lib/memory-tree.js",
   "packages/dsh-memory/lib/operation-lock.js",
   "packages/dsh-memory/lib/safe-clear.py",
@@ -72,6 +73,8 @@ const allowed = new Set([
   "tests/test_dsh_memory_init.sh",
   "tests/test_dsh_memory_install.sh",
   "tests/test_dsh_memory_metadata.mjs",
+  "tests/test_dsh_memory_usage.mjs",
+  "tests/test_dsh_memory_context.mjs",
   "tests/test_dsh_memory_operation_lock.mjs",
   "tests/test_dsh_memory_backup.sh",
   "tests/test_dsh_memory_migrate.sh",
@@ -225,7 +228,7 @@ try {
       if (content === null) continue;
       try {
         const manifest = JSON.parse(content);
-        if (manifest.version !== "0.7.0") add("manifest version is not 0.7.0", manifestPath);
+        if (manifest.version !== "0.8.0") add("manifest version is not 0.8.0", manifestPath);
         if (manifestPath !== "package.json" && manifest.private !== true) {
           add("package is not locked against npm publication", manifestPath);
         }


### PR DESCRIPTION
## Summary
- add a host-owned `memory.context({ query, limit })` read path
- track metadata-only usage atomically in `.sync/usage.json`
- add deterministic source citations and usage-aware ordering
- bump workspace/packages to 0.8.0 and document the backend-only release
- keep the settings UI unchanged and preserve existing search/migration/sync APIs

## Verification
- `npm test`
- `npm pack --dry-run --workspace dsh-memory`
- `npm pack --dry-run --workspace dsh-memory-ui`
- cross-process usage update test

No provider calls or real memory writes are used by the tests.
