### PR TITLE
Keep headless memory sessions private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project are documented here.
 - Workspace and package lock metadata now consistently records v0.7.0.
 - Removed the Legacy migration card and controls from the settings UI; the
   host API and `dsh-memory-migrate` CLI remain available.
+- Automatic headless consolidation sessions now use a private per-run
+  persistence root, so they do not appear in the normal DSH conversation list.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ v0.2 makes every automatic write transactional:
 
 - The synchronizer copies the payload tree into an isolated staging worktree;
   headless DSH only ever sees and writes that staging copy.
+- The one-shot headless session created for consolidation is persisted under a
+  private per-run temporary root, not the user's normal DSH session store, so
+  automatic syncs do not create conversations that require manual archiving.
 - The host verifies the staged diff (paths, read-only reference, live-root
   concurrency) and applies it to the live memory repository with its own
   `recovery` + `apply` commit pair. The model never runs Git.

--- a/integrations/dsh/dsh-memory-sync
+++ b/integrations/dsh/dsh-memory-sync
@@ -293,6 +293,8 @@ fi
 STAGING_PARENT="${TMPDIR:-/tmp}/dsh-memory-sync-$$"
 STAGING="$STAGING_PARENT/staging"
 MANIFEST="$STAGING_PARENT/manifest.json"
+HEADLESS_SESSION_ROOT="$STAGING_PARENT/headless-sessions"
+HEADLESS_SESSION_PATCH="$STAGING_PARENT/headless-session.patch.yml"
 mkdir -p "$STAGING_PARENT"
 umask 077
 
@@ -302,6 +304,19 @@ apply_output="$(sync_apply stage-copy --root "$DSH_MEMORY_ROOT" --staging "$STAG
   rm -rf -- "$STAGING_PARENT"
   exit 1
 }
+
+# The rc.7 headless bundle deliberately persists every one-shot session. If
+# it uses the normal DSH_HOME, each memory consolidation appears in the Web
+# session list and must be archived manually. Keep the DSH home (settings,
+# profiles, runtime, and credentials policy) unchanged, but route only this
+# child session backend to the per-run private directory. The directory lives
+# under STAGING_PARENT and is removed with the rest of the transaction.
+cat > "$HEADLESS_SESSION_PATCH" <<EOF
+- id: session-persistence-jsonl
+  config:
+    root: $HEADLESS_SESSION_ROOT
+EOF
+chmod 600 "$HEADLESS_SESSION_PATCH"
 
 # Headless DSH writes only to the staging payload. It never sees the live
 # memory root, never runs Git, and never advances the watermark.
@@ -343,7 +358,8 @@ done
 # Run the model inside the staging worktree so its relative writes land there.
 (
   cd "$STAGING"
-  /usr/bin/env -i "${CHILD_ENV[@]}" "$DSH_EXECUTABLE" --profile headless "$STAGING_PROMPT"
+  /usr/bin/env -i "${CHILD_ENV[@]}" "$DSH_EXECUTABLE" --profile headless \
+    --patch "$HEADLESS_SESSION_PATCH" "$STAGING_PROMPT"
 )
 # The process exited successfully, so every eligible log was delivered to
 # headless DSH. Per-session NO_SIGNAL results are deliberately not guessed from

--- a/tests/test_dsh_memory_sync_env.sh
+++ b/tests/test_dsh_memory_sync_env.sh
@@ -36,7 +36,14 @@ chmod +x "$TEST_INTEGRATION/dsh-memory-init"
 cat > "$TEST_BIN/fake-dsh" <<'EOF'
 #!/bin/zsh
 set -euo pipefail
-[[ "$#" -eq 3 && "$1" == "--profile" && "$2" == "headless" && -n "$3" ]]
+[[ "$#" -eq 5 && "$1" == "--profile" && "$2" == "headless" && "$3" == "--patch" && -f "$4" && -n "$5" ]]
+grep -q -- '^- id: session-persistence-jsonl$' "$4"
+grep -q -- 'headless-sessions' "$4"
+[[ "$4" != "$DSH_HOME/sessions" ]]
+PRIVATE_SESSION_ROOT="$(/usr/bin/awk '/^[[:space:]]*root:/{print $2; exit}' "$4")"
+mkdir -p "$PRIVATE_SESSION_ROOT"
+: > "$PRIVATE_SESSION_ROOT/session.jsonl.zstd"
+print -r -- "$PRIVATE_SESSION_ROOT" > "$HOME/private-session-root.txt"
 [[ "${DSH_PERMISSION_MODE:-}" == "workspace-write" ]]
 # Simulate a model edit inside the staging worktree (the sync cds into staging).
 printf 'synthetic memory entry\n' > handbook/synthetic-entry.md
@@ -60,6 +67,10 @@ env \
   LC_SYNTHETIC="names-only" \
   PATH="$TEST_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
   zsh "$TEST_INTEGRATION/dsh-memory-sync" > "$ENV_NAMES"
+
+PRIVATE_SESSION_ROOT="$(cat "$TEST_HOME/private-session-root.txt")"
+[[ "$PRIVATE_SESSION_ROOT" != "$TEST_DSH_HOME/sessions" ]]
+[[ ! -e "$PRIVATE_SESSION_ROOT" ]]
 
 for allowed_name in \
   HOME DSH_HOME DSH_MEMORY_ROOT PATH TMPDIR LANG LC_SYNTHETIC \


### PR DESCRIPTION
Automatic memory consolidation currently invokes the rc.7 headless bundle with the normal DSH_HOME, which persists each one-shot session into the user-visible session list.

This change adds a per-run --patch overlay for session-persistence-jsonl so only consolidation sessions use a private temporary root under the transaction directory. The normal DSH settings, profiles, runtime, and credential policy remain unchanged. The private root is removed with the transaction.

Validation:
- sync env/lock/dry-run/preview/disabled tests pass
- full npm test passes
- npm pack --dry-run for both workspaces passes
- README and CHANGELOG updated