### PR TITLE
fix(memory): point staging prompt intro at the README distill/consolidate section

### DIFF
--- a/integrations/dsh/dsh-memory-sync
+++ b/integrations/dsh/dsh-memory-sync
@@ -325,7 +325,7 @@ chmod 600 "$HEADLESS_SESSION_PATCH"
 # memory root, never runs Git, and never advances the watermark.
 STAGING_PROMPT="你是 dsh-memory 的定时记忆整合代理，现在执行一次增量同步。重要：本会话自身绝不提取、绝不整合，避免自我循环。
 
-你在一个隔离的暂存记忆仓库中工作（$STAGING，git 版本化；宪法、提取/整合模板、硬规则见其 README.md，先读它）。你只能修改 $STAGING 下的 summary.md、handbook/、rollouts/、archive/；禁止修改 $STAGING/README.md，禁止创建其他文件或目录，禁止执行任何 git 命令。
+你在一个隔离的暂存记忆仓库中工作（$STAGING，git 版本化；宪法、「提炼与整合」一节的要求、硬规则见其 README.md，先读它）。你只能修改 $STAGING 下的 summary.md、handbook/、rollouts/、archive/；禁止修改 $STAGING/README.md，禁止创建其他文件或目录，禁止执行任何 git 命令。
 
 会话日志根：$DSH_HOME/sessions。同步标记：$MARKER（unix 秒时间戳文件）。
 


### PR DESCRIPTION
## 内容

修正 staging prompt 开头一行的文档漂移：`提取/整合模板` → 「提炼与整合」一节的要求（README 真实章节名）。与 T3 已修正的步骤 2/3 引用同源，属同一处残留的收尾。纯文案，无行为变更。

- `integrations/dsh/dsh-memory-sync`：1 行改动。
- deepseek-harness 侧 `bin/dsh-memory-sync:345` 已同步同样修改，两侧脚本仍仅头部布局段有差异。

## 验证

- 本地 grep 确认两仓残留为 0；Harness 侧 memory 测试套件重跑通过。
- 依赖 CI `test` 做全量回归。