### PR TITLE
fix: release dsh-memory 0.8.2 zstd sync repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-08-25
+
+### Fixed
+
+- Session filtering now distinguishes zstd frames from plain JSONL by magic
+  bytes, works under launchd's minimal `PATH`, and fails closed with
+  `zstd-unavailable` when a decoder is missing.
+- Existing memory repositories refresh the deployed session helper
+  idempotently, refuse dirty helper files, and record helper-only refresh
+  commits. This also deploys the template's credential redaction to stale
+  local installations.
+
+### Operational notes
+
+- A single session larger than `MAX_CANDIDATE_BYTES` still rejects the whole
+  batch; per-file skip-and-journal is tracked separately.
+- This release is distributed through GitHub source installs and GitHub
+  Releases; it is not published to npm.
+
 ## [0.8.1] - 2026-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ not expose the filesystem root or execute Git directly.
 
 ## Compatibility
 
-`v0.8.1` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
+`v0.8.2` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
 tested and locally integrated with a consistently pinned `0.1.0-rc.7` graph:
 
 | Component | Supported version |
@@ -88,10 +88,10 @@ contains the host plugin, the settings-page client bundle, and its
 ```zsh
 # GitHub source install (works before or without an npm publication)
 dsh plugin --profile web add github:seriousz158/dsh-memory
-
-# Registry install, once the package is available from npm
-dsh plugin --profile web add dsh-git-memory
 ```
+
+This project is distributed through GitHub source installs and GitHub Releases.
+It is not published to npm.
 
 Restart the selected DSH profile after installing. The bundle does not include
 any memory data, session logs, credentials, or the local `.dsh` directory.
@@ -103,7 +103,7 @@ Clone the repository and install its reproducible development/runtime dependenci
 ```zsh
 git clone https://github.com/seriousz158/dsh-memory.git
 cd dsh-memory
-# Use the pinned runtime that this v0.8.1 integration was tested with.
+# Use the pinned runtime that this v0.8.2 integration was tested with.
 npm install --global @deepseek-ai/dsh@0.1.0-rc.7
 dsh --version
 npm ci --ignore-scripts

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -101,7 +101,7 @@ The sync command does not install DSH. It requires a `dsh` executable on `PATH`,
 The wrapper also discovers a local Homebrew or nvm Node runtime when launchd
 starts with a minimal `PATH`; no interactive shell profile is required.
 
-The v0.8.1 host and UI packages still declare the runtime peer range
+The v0.8.2 host and UI packages still declare the runtime peer range
 `@deepseek-ai/dsh@^0.1.0-rc.6`, so DSH `rc.6` remains peer-compatible. The
 repository's reproducible clean-room and local integration baseline is
 `0.1.0-rc.7`, because the registry's `rc.6` transitive peer graph is not

--- a/integrations/dsh/dsh-memory-init
+++ b/integrations/dsh/dsh-memory-init
@@ -72,6 +72,27 @@ harden_initialized_repository() {
   chmod 700 "$MEMORY_ROOT/scripts/filter_session.py"
 }
 
+refresh_helper_script() {
+  local helper_path="$MEMORY_ROOT/scripts/filter_session.py"
+  local helper_status
+  local temporary_path
+
+  helper_status="$($git_bin -C "$MEMORY_ROOT" status --porcelain --untracked-files=all -- scripts/filter_session.py)"
+  [[ -z "$helper_status" ]] || die "refusing to refresh a dirty memory helper"
+  cmp -s "$TEMPLATE_ROOT/scripts/filter_session.py" "$helper_path" && return 0
+
+  temporary_path="$(/usr/bin/mktemp "$MEMORY_ROOT/scripts/.filter_session.py.XXXXXX")"
+  if ! "$install_bin" -m 700 "$TEMPLATE_ROOT/scripts/filter_session.py" "$temporary_path"; then
+    rm -f -- "$temporary_path"
+    die "could not stage the refreshed memory helper"
+  fi
+  mv -f -- "$temporary_path" "$helper_path"
+  chmod 700 "$helper_path"
+  "$git_bin" -C "$MEMORY_ROOT" add -- scripts/filter_session.py
+  "$git_bin" -C "$MEMORY_ROOT" commit --quiet --only -m "Refresh helper scripts" -- scripts/filter_session.py \
+    || die "could not commit the refreshed memory helper"
+}
+
 if [[ -e "$MEMORY_ROOT" || -L "$MEMORY_ROOT" ]]; then
   [[ -d "$MEMORY_ROOT" && ! -L "$MEMORY_ROOT" ]] || die "refusing a non-directory or symlink memory root"
   if "$git_bin" -C "$MEMORY_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
@@ -90,6 +111,7 @@ if [[ -e "$MEMORY_ROOT" || -L "$MEMORY_ROOT" ]]; then
       die "memory .sync/.gitignore is unsafe"
     fi
     validate_initialized_repository || die "memory root is an incomplete DSH memory repository"
+    refresh_helper_script
     harden_initialized_repository || die "could not restore private memory repository permissions"
     print -- "$root_real"
     exit 0

--- a/integrations/dsh/dsh-memory-sync
+++ b/integrations/dsh/dsh-memory-sync
@@ -22,7 +22,7 @@ MARKER="$DSH_MEMORY_ROOT/.last-sync"
 PENDING_CANDIDATES="$DSH_MEMORY_ROOT/.sync/pending-candidates.json"
 DSH_BIN="${DSH_BIN:-dsh}"
 DSH_PERMISSION_MODE="${DSH_PERMISSION_MODE:-workspace-write}"
-SYNC_POLICY_VERSION="${DSH_MEMORY_SYNC_POLICY_VERSION:-v0.8.1}"
+SYNC_POLICY_VERSION="${DSH_MEMORY_SYNC_POLICY_VERSION:-v0.8.2}"
 MAX_CANDIDATE_SESSIONS="${DSH_MEMORY_MAX_CANDIDATE_SESSIONS:-10}"
 MAX_CANDIDATE_BYTES="${DSH_MEMORY_MAX_CANDIDATE_BYTES:-8388608}"
 RETRY_COOLDOWN_SECONDS="${DSH_MEMORY_RETRY_COOLDOWN_SECONDS:-3600}"
@@ -545,14 +545,20 @@ if [[ "${#CANDIDATE_FILES}" -gt 0 && ! -x "$FILTER_SESSION" ]]; then
 fi
 mkdir -m 700 -p "$SANITIZED_INPUT_ROOT"
 : > "$CANDIDATE_MANIFEST_TMP"
+FILTER_ERROR_TMP="$STAGING_PARENT/filter-error.txt"
 if [[ "${#CANDIDATE_FILES}" -gt 0 ]]; then
   input_index=0
   for candidate in "${CANDIDATE_FILES[@]}"; do
     input_name="$(printf 'session-%04d.md' "$input_index")"
     input_path="$SANITIZED_INPUT_ROOT/$input_name"
-    if ! "$PYTHON_BIN" "$FILTER_SESSION" "$candidate" > "$input_path"; then
-      write_failure_record "input-filter-failed" staging
-      print -u2 -- "dsh-memory-sync: failed to redact a candidate session"
+    : > "$FILTER_ERROR_TMP"
+    if ! "$PYTHON_BIN" "$FILTER_SESSION" "$candidate" > "$input_path" 2>"$FILTER_ERROR_TMP"; then
+      filter_error_code="input-filter-failed"
+      if grep -q -- '^zstd-unavailable:' "$FILTER_ERROR_TMP"; then
+        filter_error_code="zstd-unavailable"
+      fi
+      write_failure_record "$filter_error_code" staging
+      print -u2 -- "dsh-memory-sync: failed to filter a candidate session: $filter_error_code"
       rm -rf -- "$STAGING_PARENT"
       exit 1
     fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-git-memory",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-git-memory",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "workspaces": [
         "packages/dsh-memory",
@@ -1143,7 +1143,7 @@
       }
     },
     "packages/dsh-memory": {
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-git-memory",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": false,
   "description": "A local Git-backed long-term memory bundle for DeepSeek Harness",
   "type": "module",

--- a/packages/dsh-memory/package.json
+++ b/packages/dsh-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "description": "Automatic local long-term memory for DSH",
   "type": "module",

--- a/packages/dsh-memory/templates/scripts/filter_session.py
+++ b/packages/dsh-memory/templates/scripts/filter_session.py
@@ -6,7 +6,9 @@ Usage:
   zstd -dc <session.jsonl.zstd> | python3 filter_session.py -
 """
 import json
+import os
 import re
+import shutil
 import subprocess
 import sys
 
@@ -15,6 +17,8 @@ RESULT_MAX = 400
 MESSAGE_MAX = 2000
 METADATA_MAX = 400
 REDACTION = "[REDACTED]"
+ZSTD_MAGIC = b"\x28\xb5\x2f\xfd"
+ZSTD_FALLBACKS = ("/opt/homebrew/bin/zstd", "/usr/local/bin/zstd")
 
 BEARER_RE = re.compile(r"(?i)\bbearer[ \t]+[A-Za-z0-9._~+/=-]{3,}")
 SK_KEY_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{3,}", re.IGNORECASE)
@@ -158,25 +162,59 @@ def render(events):
     return "\n".join(out)
 
 
+class ZstdUnavailable(RuntimeError):
+    """The input is a zstd frame but no usable decoder is available."""
+
+
+def resolve_zstd() -> str:
+    """Resolve zstd without silently ignoring an explicit operator override."""
+    if "DPSK_ZSTD" in os.environ:
+        candidate = os.environ.get("DPSK_ZSTD", "")
+        if not candidate or not os.path.isfile(candidate) or not os.access(candidate, os.X_OK):
+            raise ZstdUnavailable("DPSK_ZSTD is set but is not an executable zstd binary")
+        return candidate
+
+    candidate = shutil.which("zstd")
+    if candidate:
+        return candidate
+    for candidate in ZSTD_FALLBACKS:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    raise ZstdUnavailable("no executable zstd binary was found")
+
+
+def read_session_bytes(path: str) -> bytes:
+    """Read plain JSONL or decode a file whose bytes identify a zstd frame."""
+    if path == "-":
+        return sys.stdin.buffer.read()
+
+    with open(path, "rb") as handle:
+        prefix = handle.read(4)
+        if prefix != ZSTD_MAGIC:
+            handle.seek(0)
+            return handle.read()
+
+    zstd = resolve_zstd()
+    try:
+        return subprocess.run(
+            [zstd, "-dc", path],
+            capture_output=True,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ZstdUnavailable("zstd could not decode the session input") from exc
+
+
 def main():
     if len(sys.argv) < 2:
         print(__doc__)
         sys.exit(2)
     path = sys.argv[1]
-    if path == "-":
-        raw = sys.stdin.buffer.read()
-    elif path.endswith(".zstd"):
-        try:
-            raw = subprocess.run(["zstd", "-dc", path], capture_output=True, check=False).stdout
-        except FileNotFoundError:
-            # Synthetic fixtures and minimal launchd environments may not have
-            # the optional zstd binary. Treat the input as an already-decoded
-            # JSONL stream rather than failing the whole sync.
-            with open(path, "rb") as handle:
-                raw = handle.read()
-    else:
-        with open(path, "rb") as handle:
-            raw = handle.read()
+    try:
+        raw = read_session_bytes(path)
+    except ZstdUnavailable as exc:
+        print(f"zstd-unavailable: {exc}", file=sys.stderr)
+        sys.exit(1)
     events = []
     for line in raw.decode("utf-8", errors="replace").splitlines():
         if not line.strip():

--- a/tests/run-memory-tests.sh
+++ b/tests/run-memory-tests.sh
@@ -27,6 +27,7 @@ zsh tests/test_dsh_memory_init.sh
 zsh tests/test_dsh_memory_install.sh
 zsh tests/test_dsh_memory_sync_disabled.sh
 zsh tests/test_dsh_memory_sync_env.sh
+zsh tests/test_dsh_memory_sync_zstd_failure.sh
 zsh tests/test_dsh_memory_sync_dry_run.sh
 zsh tests/test_dsh_memory_sync_lock.sh
 zsh tests/test_dsh_memory_sync_batch.sh

--- a/tests/test_dsh_memory_init.sh
+++ b/tests/test_dsh_memory_init.sh
@@ -99,4 +99,29 @@ if DSH_MEMORY_ROOT="$INCOMPLETE_REPOSITORY" "$INITIALIZER" >/dev/null 2>&1; then
   exit 1
 fi
 
+REFRESH_HOME="$TEST_ROOT/refresh-home"
+DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
+REFRESH_MEMORY_ROOT="$REFRESH_HOME/storages/memory"
+REFRESH_TEMPLATE="$FIXTURE_REPO/packages/dsh-memory/templates/scripts/filter_session.py"
+REFRESH_HELPER="$REFRESH_MEMORY_ROOT/scripts/filter_session.py"
+print -r -- '# refresh-marker-one' >> "$REFRESH_TEMPLATE"
+refresh_head_before="$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)"
+DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
+test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" != "$refresh_head_before"
+test "$(git -C "$REFRESH_MEMORY_ROOT" log -1 --format=%s)" = "Refresh helper scripts"
+test "$(git -C "$REFRESH_MEMORY_ROOT" diff-tree --no-commit-id --name-only -r HEAD)" = "scripts/filter_session.py"
+cmp -s "$REFRESH_TEMPLATE" "$REFRESH_HELPER"
+refresh_head_after="$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)"
+DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
+test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" = "$refresh_head_after"
+
+print -r -- '# uncommitted-helper-change' >> "$REFRESH_HELPER"
+print -r -- '# refresh-marker-two' >> "$REFRESH_TEMPLATE"
+if DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null 2>&1; then
+  print -u2 -- "initializer overwrote a dirty helper"
+  exit 1
+fi
+grep -q -- '# uncommitted-helper-change' "$REFRESH_HELPER"
+test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" = "$refresh_head_after"
+
 print "dsh-memory initializer tests passed"

--- a/tests/test_dsh_memory_marketplace.mjs
+++ b/tests/test_dsh_memory_marketplace.mjs
@@ -11,7 +11,7 @@ const manifest = JSON.parse(await readFile(join(project, "package.json"), "utf8"
 const patch = await readFile(join(project, "packages/dsh-git-memory/cordis.patch.yml"), "utf8");
 
 assert.equal(manifest.name, "dsh-git-memory");
-assert.equal(manifest.version, "0.8.1");
+assert.equal(manifest.version, "0.8.2");
 assert.notEqual(manifest.private, true);
 assert.equal(manifest.main, "./packages/dsh-git-memory/lib/index.js");
 assert.equal(manifest.exports["."], "./packages/dsh-git-memory/lib/index.js");

--- a/tests/test_dsh_memory_redaction.mjs
+++ b/tests/test_dsh_memory_redaction.mjs
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -141,5 +144,61 @@ for (const benign of [
 assert.ok(result.stdout.includes("[REDACTED]"), "redaction marker missing");
 assert.ok(result.stdout.includes("$HOME"), "home path was not normalized");
 assert.equal(result.stdout.includes("sk-"), false, "redaction must run before truncation");
+
+const tempRoot = await mkdtemp(join(tmpdir(), "dsh-memory-filter-zstd."));
+try {
+  const plainPath = join(tempRoot, "plain.jsonl.zstd");
+  const magicPath = join(tempRoot, "invalid.jsonl.zstd");
+  const compressedPath = join(tempRoot, "compressed.jsonl.zstd");
+  const missingZstd = join(tempRoot, "missing-zstd");
+  await writeFile(plainPath, input);
+  await writeFile(magicPath, Buffer.from([0x28, 0xb5, 0x2f, 0xfd, 0x00]));
+
+  const plainFile = spawnSync("python3", [filterScript, plainPath], {
+    encoding: "utf8",
+    env: { ...process.env, DPSK_ZSTD: missingZstd },
+  });
+  assert.equal(plainFile.status, 0, plainFile.stderr || "plain JSONL file was rejected");
+  assert.ok(plainFile.stdout.includes("benign-user-text"));
+
+  const missingBinary = spawnSync("python3", [filterScript, magicPath], {
+    encoding: "utf8",
+    env: { ...process.env, DPSK_ZSTD: missingZstd },
+  });
+  assert.notEqual(missingBinary.status, 0, "zstd magic input unexpectedly succeeded");
+  assert.match(missingBinary.stderr, /zstd-unavailable/);
+
+  const zstdCandidates = [
+    process.env.DPSK_ZSTD,
+    "/opt/homebrew/bin/zstd",
+    "/usr/local/bin/zstd",
+  ].filter(Boolean);
+  let zstdPath = null;
+  for (const candidate of zstdCandidates) {
+    try {
+      await access(candidate, constants.X_OK);
+      zstdPath = candidate;
+      break;
+    } catch {
+      // Try the next platform-specific location.
+    }
+  }
+  if (zstdPath) {
+    const compressed = spawnSync(zstdPath, ["-q", "-f", "-o", compressedPath, plainPath], {
+      encoding: "utf8",
+    });
+    assert.equal(compressed.status, 0, compressed.stderr || "zstd fixture creation failed");
+    const decoded = spawnSync("python3", [filterScript, compressedPath], {
+      encoding: "utf8",
+      env: { ...process.env, DPSK_ZSTD: zstdPath },
+    });
+    assert.equal(decoded.status, 0, decoded.stderr || "zstd input was not decoded");
+    assert.ok(decoded.stdout.includes("benign-user-text"));
+  } else {
+    console.log("dsh-memory zstd integration fixture skipped: no executable zstd found");
+  }
+} finally {
+  await rm(tempRoot, { recursive: true, force: true });
+}
 
 console.log("dsh-memory redaction test passed");

--- a/tests/test_dsh_memory_sync_zstd_failure.sh
+++ b/tests/test_dsh_memory_sync_zstd_failure.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+PROJECT_DIR="$(cd -- "$(dirname -- "$0")/.." && pwd -P)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/dsh-memory-sync-zstd-failure.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+TEST_DSH_HOME="$TEST_ROOT/dsh-home"
+TEST_MEMORY_ROOT="$TEST_ROOT/memory"
+TEST_INTEGRATION="$TEST_ROOT/integrations/dsh"
+TEST_BIN="$TEST_ROOT/bin"
+mkdir -p "$TEST_DSH_HOME/sessions" "$TEST_INTEGRATION" "$TEST_BIN" \
+  "$TEST_ROOT/packages/dsh-memory/templates/.sync" \
+  "$TEST_ROOT/packages/dsh-memory/templates/scripts"
+
+cp "$PROJECT_DIR/integrations/dsh/dsh-memory-sync" "$TEST_INTEGRATION/dsh-memory-sync"
+cp "$PROJECT_DIR/integrations/dsh/dsh-memory-init" "$TEST_INTEGRATION/dsh-memory-init"
+cp "$PROJECT_DIR/packages/dsh-memory/lib/sync-apply.py" "$TEST_INTEGRATION/sync-apply.py"
+cp "$PROJECT_DIR/packages/dsh-memory/templates/README.md" "$TEST_ROOT/packages/dsh-memory/templates/README.md"
+cp "$PROJECT_DIR/packages/dsh-memory/templates/.sync/.gitignore" "$TEST_ROOT/packages/dsh-memory/templates/.sync/.gitignore"
+cp "$PROJECT_DIR/packages/dsh-memory/templates/scripts/filter_session.py" "$TEST_ROOT/packages/dsh-memory/templates/scripts/filter_session.py"
+chmod +x "$TEST_INTEGRATION/dsh-memory-sync" "$TEST_INTEGRATION/dsh-memory-init"
+
+DSH_HOME="$TEST_DSH_HOME" DSH_MEMORY_ROOT="$TEST_MEMORY_ROOT" "$TEST_INTEGRATION/dsh-memory-init" >/dev/null
+touch -t 200001010000 "$TEST_MEMORY_ROOT/.last-sync"
+/usr/bin/python3 - "$TEST_DSH_HOME/sessions/session.jsonl.zstd" <<'PY'
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[1]).write_bytes(bytes((0x28, 0xB5, 0x2F, 0xFD, 0x00)))
+PY
+touch -t 200001010001 "$TEST_DSH_HOME/sessions/session.jsonl.zstd"
+
+cat > "$TEST_BIN/should-not-run" <<'EOF'
+#!/bin/zsh
+print -u2 -- 'fake DSH must not run when zstd is unavailable'
+exit 99
+EOF
+chmod +x "$TEST_BIN/should-not-run"
+
+if env \
+  HOME="$TEST_ROOT/home" \
+  DSH_HOME="$TEST_DSH_HOME" \
+  DSH_MEMORY_ROOT="$TEST_MEMORY_ROOT" \
+  DSH_BIN="$TEST_BIN/should-not-run" \
+  DPSK_MEMORY_SYNC_HELPER="$TEST_INTEGRATION/sync-apply.py" \
+  DPSK_ZSTD="$TEST_ROOT/missing-zstd" \
+  PATH="$TEST_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+  zsh "$TEST_INTEGRATION/dsh-memory-sync" >"$TEST_ROOT/stdout" 2>"$TEST_ROOT/stderr"; then
+  print -u2 -- 'sync unexpectedly succeeded with unavailable zstd'
+  exit 1
+fi
+grep -q -- 'zstd-unavailable' "$TEST_ROOT/stderr"
+
+/usr/bin/python3 - "$TEST_MEMORY_ROOT/.sync/runs" "$TEST_MEMORY_ROOT/.sync/failure-sentinel.json" <<'PY'
+import json
+import pathlib
+import sys
+
+runs = sorted(pathlib.Path(sys.argv[1]).glob("*.json"))
+assert runs, runs
+record = json.loads(runs[-1].read_text())
+assert record["error_code"] == "zstd-unavailable", record
+sentinel = json.loads(pathlib.Path(sys.argv[2]).read_text())
+assert sentinel["error_code"] == "zstd-unavailable", sentinel
+PY
+
+print -- "dsh-memory zstd failure mapping test passed"

--- a/tools/public-tree-check.mjs
+++ b/tools/public-tree-check.mjs
@@ -102,6 +102,7 @@ const allowed = new Set([
   "tests/test_dsh_memory_sync_disabled.sh",
   "tests/test_dsh_memory_sync_dry_run.sh",
   "tests/test_dsh_memory_sync_env.sh",
+  "tests/test_dsh_memory_sync_zstd_failure.sh",
   "tests/test_dsh_memory_sync_lock.sh",
   "tests/test_dsh_memory_sync_batch.sh",
   "tests/test_dsh_memory_sync_preview.sh",
@@ -240,12 +241,18 @@ try {
       if (content !== null && hasUnresolvedMergeMarker(content)) add("unresolved merge marker", file);
     }
 
-    for (const manifestPath of ["package.json", "packages/dsh-memory/package.json", "packages/dsh-memory-ui/package.json"]) {
+    const expectedManifestVersions = {
+      "package.json": "0.8.2",
+      "packages/dsh-memory/package.json": "0.8.2",
+      "packages/dsh-memory-ui/package.json": "0.8.1",
+    };
+    for (const manifestPath of Object.keys(expectedManifestVersions)) {
       const content = readSnapshotText(snapshot, manifestPath);
       if (content === null) continue;
       try {
         const manifest = JSON.parse(content);
-        if (manifest.version !== "0.8.1") add("manifest version is not 0.8.1", manifestPath);
+        const expectedVersion = expectedManifestVersions[manifestPath];
+        if (manifest.version !== expectedVersion) add(`manifest version is not ${expectedVersion}`, manifestPath);
         if (manifestPath !== "package.json" && manifest.private !== true) {
           add("package is not locked against npm publication", manifestPath);
         }


### PR DESCRIPTION
## Summary

- Fix launchd/minimal-PATH session filtering by distinguishing zstd frames from plain JSONL via magic bytes.
- Resolve zstd using `DPSK_ZSTD`, `PATH`, and standard Homebrew locations; explicit invalid `DPSK_ZSTD` fails closed as `zstd-unavailable`.
- Refresh stale deployed helpers safely for existing memory repositories: idempotent checksum check, dirty-helper fail-closed, atomic replacement, and helper-only Git commit.
- Bump the public bundle and host workspace to `0.8.2`; keep `dsh-memory-ui` at `0.8.1`.

The upstream template already contains credential redaction. The deployment fix ensures that stale local helpers are replaced with that redacting template, closing the existing deployed-helper privacy gap.

## Operational notes

- A single session larger than `MAX_CANDIDATE_BYTES` still rejects the whole batch. Per-file skip-and-journal is intentionally left for a follow-up issue.
- Because capped batches do not advance `.last-sync`, the first recovery run may clear the failure sentinel while leaving the watermark unchanged. The watermark advances only after the final non-truncated run.
- This release is distributed through GitHub source installs and GitHub Releases; it is not published to npm.

## Verification

- `npm test` passes, including isolated browser E2E and release guards.
- Added regression coverage for zstd magic detection, unavailable zstd mapping, plain JSONL compatibility, redaction, and helper refresh/dirty behavior.
- No real model synchronization was run by this change.
