### PR TITLE
feat: v0.8.3 single-writer contract, metadata audit, and scan-only acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [0.8.3] - 2026-09-01
+
+### Added
+
+- Metadata audit: `status`/`health` now report `metadataValid`,
+  `validMetadataCount`, `invalidMetadataCount`, and up to 20 `invalidMetadata`
+  entries. Metadata anomalies surface as a dedicated UI warning ("记忆数据格式
+  异常") and never fold into `needsManualRecovery`.
+- Search and context exclude records with invalid metadata from retrieval and
+  return per-file `warnings` with stable error codes instead of failing.
+- Flow-style front matter collections (`tags: [a, b]`) are rejected with the
+  stable `flow-style-metadata` code; new/updated records must use canonical
+  block lists.
+- Single-writer coordination: the memory section now instructs normal sessions
+  to treat the memory repository as read-only and record memory requests in
+  their session output; the periodic transactional sync performs extraction,
+  consolidation, and git commits. README templates document the write boundary
+  and the canonical front matter format.
+- README.md, `.sync/.gitignore`, and `scripts/filter_session.py` are managed
+  readonly templates: identical checksum is a no-op, a dirty live copy fails
+  closed, changed files are replaced atomically and committed once as
+  "Refresh managed memory templates".
+- `--scan-only [--json]` is the zero-Provider acceptance path: it reports
+  candidates, raw bytes, digests, pending state, and the watermark without
+  starting DSH, acquiring the operation lock, writing a journal, or advancing
+  the watermark. `--dry-run` is a deprecated alias that no longer runs the
+  model.
+- Prompt freshness: the memory section re-renders when `summary.md` changes
+  (polled every 5s, debounced, watcher stopped on cleanup, brief file absence
+  keeps the previous snapshot).
+
+### Changed
+
+- The memory skill (v1.2.0) turns extract/consolidate/forget into memory
+  requests recorded in session output; direct file writes and git commits are
+  removed from normal sessions. Forget defaults to archive/correction with
+  explicit `supersedes`.
+
 ## [0.8.2] - 2026-08-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ not expose the filesystem root or execute Git directly.
 
 ## Compatibility
 
-`v0.8.2` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
+`v0.8.3` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
 tested and locally integrated with a consistently pinned `0.1.0-rc.7` graph:
 
 | Component | Supported version |
@@ -103,7 +103,7 @@ Clone the repository and install its reproducible development/runtime dependenci
 ```zsh
 git clone https://github.com/seriousz158/dsh-memory.git
 cd dsh-memory
-# Use the pinned runtime that this v0.8.2 integration was tested with.
+# Use the pinned runtime that this v0.8.3 integration was tested with.
 npm install --global @deepseek-ai/dsh@0.1.0-rc.7
 dsh --version
 npm ci --ignore-scripts

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -101,7 +101,7 @@ The sync command does not install DSH. It requires a `dsh` executable on `PATH`,
 The wrapper also discovers a local Homebrew or nvm Node runtime when launchd
 starts with a minimal `PATH`; no interactive shell profile is required.
 
-The v0.8.2 host and UI packages still declare the runtime peer range
+The v0.8.3 host and UI packages still declare the runtime peer range
 `@deepseek-ai/dsh@^0.1.0-rc.6`, so DSH `rc.6` remains peer-compatible. The
 repository's reproducible clean-room and local integration baseline is
 `0.1.0-rc.7`, because the registry's `rc.6` transitive peer graph is not

--- a/integrations/dsh/dsh-memory-init
+++ b/integrations/dsh/dsh-memory-init
@@ -72,25 +72,41 @@ harden_initialized_repository() {
   chmod 700 "$MEMORY_ROOT/scripts/filter_session.py"
 }
 
-refresh_helper_script() {
-  local helper_path="$MEMORY_ROOT/scripts/filter_session.py"
-  local helper_status
+refresh_managed_templates() {
+  # Managed readonly files: the host owns them; the model never edits them.
+  # For each template: identical checksum is a no-op; a dirty (uncommitted)
+  # live copy fails closed; otherwise the file is replaced atomically and a
+  # single commit records only the changed managed files.
+  typeset -a managed_relpaths
+  managed_relpaths=(README.md .sync/.gitignore scripts/filter_session.py)
+  typeset -a changed
+  changed=()
+  local relpath
+  local live_path
+  local template_path
+  local entry_status
   local temporary_path
-
-  helper_status="$($git_bin -C "$MEMORY_ROOT" status --porcelain --untracked-files=all -- scripts/filter_session.py)"
-  [[ -z "$helper_status" ]] || die "refusing to refresh a dirty memory helper"
-  cmp -s "$TEMPLATE_ROOT/scripts/filter_session.py" "$helper_path" && return 0
-
-  temporary_path="$(/usr/bin/mktemp "$MEMORY_ROOT/scripts/.filter_session.py.XXXXXX")"
-  if ! "$install_bin" -m 700 "$TEMPLATE_ROOT/scripts/filter_session.py" "$temporary_path"; then
-    rm -f -- "$temporary_path"
-    die "could not stage the refreshed memory helper"
-  fi
-  mv -f -- "$temporary_path" "$helper_path"
-  chmod 700 "$helper_path"
-  "$git_bin" -C "$MEMORY_ROOT" add -- scripts/filter_session.py
-  "$git_bin" -C "$MEMORY_ROOT" commit --quiet --only -m "Refresh helper scripts" -- scripts/filter_session.py \
-    || die "could not commit the refreshed memory helper"
+  for relpath in "${managed_relpaths[@]}"; do
+    live_path="$MEMORY_ROOT/$relpath"
+    template_path="$TEMPLATE_ROOT/$relpath"
+    entry_status="$($git_bin -C "$MEMORY_ROOT" status --porcelain --untracked-files=all -- "$relpath")"
+    [[ -z "$entry_status" ]] || die "refusing to refresh a dirty managed template: $relpath"
+    cmp -s "$template_path" "$live_path" && continue
+    temporary_path="$(/usr/bin/mktemp "$MEMORY_ROOT/.$(basename -- "$relpath").refresh.XXXXXX")"
+    if ! "$install_bin" -m 600 "$template_path" "$temporary_path"; then
+      rm -f -- "$temporary_path"
+      die "could not stage the refreshed managed template: $relpath"
+    fi
+    mv -f -- "$temporary_path" "$live_path"
+    chmod 600 "$live_path"
+    changed+=("$relpath")
+  done
+  (( ${#changed} == 0 )) && return 0
+  local helper_path="$MEMORY_ROOT/scripts/filter_session.py"
+  [[ -f "$helper_path" ]] && chmod 700 "$helper_path"
+  "$git_bin" -C "$MEMORY_ROOT" add -- "${changed[@]}"
+  "$git_bin" -C "$MEMORY_ROOT" commit --quiet --only -m "Refresh managed memory templates" -- "${changed[@]}" \
+    || die "could not commit the refreshed managed templates"
 }
 
 if [[ -e "$MEMORY_ROOT" || -L "$MEMORY_ROOT" ]]; then
@@ -111,7 +127,7 @@ if [[ -e "$MEMORY_ROOT" || -L "$MEMORY_ROOT" ]]; then
       die "memory .sync/.gitignore is unsafe"
     fi
     validate_initialized_repository || die "memory root is an incomplete DSH memory repository"
-    refresh_helper_script
+    refresh_managed_templates
     harden_initialized_repository || die "could not restore private memory repository permissions"
     print -- "$root_real"
     exit 0

--- a/integrations/dsh/dsh-memory-sync
+++ b/integrations/dsh/dsh-memory-sync
@@ -6,11 +6,13 @@
 # Git commits (recovery + apply), records a run journal, and only then advances
 # the .last-sync watermark. A host-side operation lock serializes sync runs and
 # an active-run record lets an interrupted run be recovered on the next sync.
-# A --dry-run flag reports the candidate diff without touching the live root,
-# the journal, the lock, or Git.
+# v0.8.3: --scan-only --json reports candidates, raw bytes, pending state, and
+# the watermark with zero side effects (no DSH, no provider, no lock, no
+# journal, no watermark move). --dry-run is a deprecated alias of --scan-only
+# and never runs the model; a model-generated diff requires --preview <id>.
 # Zero-change runs journal a no_change record and advance the watermark so
-# the same candidate window is never rescanned; dry-run and preview runs
-# remain side-effect free (no journal record, no watermark move).
+# the same candidate window is never rescanned; preview runs remain
+# side-effect free (no journal record, no watermark move).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd -P)"
@@ -22,7 +24,7 @@ MARKER="$DSH_MEMORY_ROOT/.last-sync"
 PENDING_CANDIDATES="$DSH_MEMORY_ROOT/.sync/pending-candidates.json"
 DSH_BIN="${DSH_BIN:-dsh}"
 DSH_PERMISSION_MODE="${DSH_PERMISSION_MODE:-workspace-write}"
-SYNC_POLICY_VERSION="${DSH_MEMORY_SYNC_POLICY_VERSION:-v0.8.2}"
+SYNC_POLICY_VERSION="${DSH_MEMORY_SYNC_POLICY_VERSION:-v0.8.3}"
 MAX_CANDIDATE_SESSIONS="${DSH_MEMORY_MAX_CANDIDATE_SESSIONS:-10}"
 MAX_CANDIDATE_BYTES="${DSH_MEMORY_MAX_CANDIDATE_BYTES:-8388608}"
 RETRY_COOLDOWN_SECONDS="${DSH_MEMORY_RETRY_COOLDOWN_SECONDS:-3600}"
@@ -38,7 +40,7 @@ CANDIDATE_MANIFEST_TMP=""
 CANDIDATE_TRUNCATED=0
 CANDIDATE_LIMIT_ERROR=""
 
-DRY_RUN=0
+SCAN_ONLY=0
 PREVIEW_MODE=0
 APPLY_PREVIEW=""
 DISCARD_PREVIEW=""
@@ -47,7 +49,15 @@ RETRY_FAILED=0
 PREVIEW_ID=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --dry-run) DRY_RUN=1; shift ;;
+    # --dry-run is a deprecated alias of --scan-only: it reports the candidate
+    # scan and never starts DSH or a provider. A model-generated diff requires
+    # an explicit --preview <id>.
+    --dry-run)
+      SCAN_ONLY=1
+      print -u2 -- "dsh-memory-sync: --dry-run is deprecated and no longer runs the model; use --scan-only to scan, or --preview <id> for a model-generated diff."
+      shift
+      ;;
+    --scan-only) SCAN_ONLY=1; shift ;;
     --preview)
       PREVIEW_MODE=1
       PREVIEW_ID="${2:-}"
@@ -70,8 +80,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 # The preview management modes are mutually exclusive with a normal sync.
-if [[ "$DRY_RUN" == "1" && "$PREVIEW_MODE" == "1" ]]; then
-  print -u2 -- "dsh-memory-sync: --dry-run and --preview are mutually exclusive"
+if [[ "$SCAN_ONLY" == "1" && "$PREVIEW_MODE" == "1" ]]; then
+  print -u2 -- "dsh-memory-sync: --scan-only and --preview are mutually exclusive"
   exit 2
 fi
 management_modes=0
@@ -236,7 +246,7 @@ PY
 
 write_pending_candidates() {
   if [[ "$CANDIDATE_TRUNCATED" != "1" ]]; then
-    [[ "$DRY_RUN" == "0" && "$PREVIEW_MODE" == "0" ]] && rm -f -- "$PENDING_CANDIDATES"
+    [[ "$PREVIEW_MODE" == "0" ]] && rm -f -- "$PENDING_CANDIDATES"
     return 0
   fi
   "$PYTHON_BIN" - "$PENDING_CANDIDATES" "${CANDIDATE_FILES[@]}" <<'PY'
@@ -305,6 +315,10 @@ if [[ ! -x "$INITIALIZER" ]]; then
   exit 127
 fi
 
+# Scan-only mode is a read-only inspection: it must not run the initializer
+# (which can commit refreshed managed templates), acquire a lock, write a
+# journal, or advance the watermark.
+
 # Build a small, credential-free base environment before invoking any child.
 # The initializer only needs local filesystem and Git access; provider values
 # are intentionally unavailable until the final DSH process is started.
@@ -325,7 +339,46 @@ for env_name in ${(k)parameters}; do
   fi
 done
 
-/usr/bin/env -i "${BASE_ENV[@]}" "$INITIALIZER" >/dev/null
+if [[ "$SCAN_ONLY" != "1" ]]; then
+  /usr/bin/env -i "${BASE_ENV[@]}" "$INITIALIZER" >/dev/null
+fi
+
+# --- Scan-only mode (--scan-only [--json]) ---
+# Reports candidates, raw bytes, pending state, and the watermark without
+# starting DSH or a provider, without acquiring the operation lock, without
+# writing a journal, and without advancing the watermark. This is the
+# zero-Provider acceptance path; a model-generated diff requires an explicit
+# --preview <id>.
+emit_scan_only() {
+  local candidates_json="["
+  local candidate
+  local size
+  local digest
+  local first=1
+  for candidate in "${CANDIDATE_FILES[@]}"; do
+    size="$(stat -f %z -- "$candidate" 2>/dev/null || print 0)"
+    digest="$(candidate_file_digest "$candidate")"
+    (( first == 1 )) || candidates_json+=","
+    first=0
+    candidates_json+="{\"path\":\"$candidate\",\"bytes\":$size,\"digest\":\"$digest\"}"
+  done
+  candidates_json+="]"
+  local pending_count=0
+  [[ -f "$PENDING_CANDIDATES" ]] && pending_count="$(pending_candidate_lines | wc -l | tr -d ' ')"
+  local watermark_state="absent"
+  [[ -f "$MARKER" ]] && watermark_state="set"
+  printf '{"ok":true,"scanOnly":true,"memoryRoot":"%s","watermark":"%s","candidateSessions":%s,"candidateBytes":%s,"truncated":%s,"limitError":%s,"pendingEntries":%s,"candidates":%s}\n' \
+    "$DSH_MEMORY_ROOT" \
+    "$watermark_state" \
+    "$CANDIDATE_SESSIONS" \
+    "$CANDIDATE_BYTES" \
+    "$([[ "$CANDIDATE_TRUNCATED" == "1" ]] && print true || print false)" \
+    "$([[ -n "$CANDIDATE_LIMIT_ERROR" ]] && printf '"%s"' "$CANDIDATE_LIMIT_ERROR" || print null)" \
+    "$pending_count" \
+    "$candidates_json"
+}
+
+
 
 # --- Preview management modes (--apply-preview / --discard-preview) ---
 # These are short host-side operations handled before any session scan: they
@@ -416,22 +469,30 @@ if [[ -f "$MARKER" ]]; then
   CANDIDATE_DIGEST="$(candidate_digest "${CANDIDATE_FILES[@]}")"
   if [[ -n "$CANDIDATE_LIMIT_ERROR" ]]; then
     progress "candidate batch rejected: $CANDIDATE_LIMIT_ERROR"
-  elif [[ "$CANDIDATE_SESSIONS" == "0" ]]; then
-    [[ "$DRY_RUN" == "0" && "$PREVIEW_MODE" == "0" ]] && rm -f -- "$PENDING_CANDIDATES"
-    if [[ "$DRY_RUN" == "1" ]]; then
-      if [[ "$JSON_OUTPUT" == "1" ]]; then
-        printf '{"ok":true,"dryRun":true,"candidateSessions":0,"changedPaths":[],"message":"no new idle session logs"}\n'
-      else
-        echo "dsh-memory-sync: dry-run: no new idle session logs since $(stat -f '%Sm' "$MARKER"), nothing to do."
-      fi
-    else
-      echo "dsh-memory-sync: no new idle session logs since $(stat -f '%Sm' "$MARKER"), nothing to do."
-    fi
+  elif [[ "$CANDIDATE_SESSIONS" == "0" && "$SCAN_ONLY" != "1" ]]; then
+    # Scan-only stays side-effect free: zero candidates are reported through
+    # the scan-only output paths below instead of this early exit, and a
+    # read-only inspection must never clear pending state as a side effect.
+    [[ "$PREVIEW_MODE" == "0" ]] && rm -f -- "$PENDING_CANDIDATES"
+    echo "dsh-memory-sync: no new idle session logs since $(stat -f '%Sm' "$MARKER"), nothing to do."
     exit 0
   fi
   progress "$CANDIDATE_SESSIONS new idle session log(s), starting headless consolidation…"
 else
   progress "first run — marker will be created, historical sessions skipped."
+fi
+
+if [[ "$SCAN_ONLY" == "1" ]]; then
+  if [[ "$JSON_OUTPUT" == "1" ]]; then
+    emit_scan_only
+  elif [[ -n "$CANDIDATE_LIMIT_ERROR" ]]; then
+    print -u2 -- "dsh-memory-sync: scan-only: candidate batch rejected: $CANDIDATE_LIMIT_ERROR"
+  elif [[ "$CANDIDATE_SESSIONS" == "0" ]]; then
+    echo "dsh-memory-sync: scan-only: no new idle session logs, nothing to do."
+  else
+    echo "dsh-memory-sync: scan-only: $CANDIDATE_SESSIONS candidate session(s), $CANDIDATE_BYTES bytes$( [[ "$CANDIDATE_TRUNCATED" == "1" ]] && print ', truncated' )."
+  fi
+  exit 0
 fi
 
 DSH_EXECUTABLE="$(command -v -- "$DSH_BIN" 2>/dev/null || true)"
@@ -462,54 +523,44 @@ cleanup_sync_operation() {
 }
 trap cleanup_sync_operation EXIT
 
-if [[ "$DRY_RUN" == "0" ]]; then
-  lock_output=""
-  if ! lock_output="$(sync_apply acquire-lock --root "$DSH_MEMORY_ROOT" --operation-name sync --run-id "$RUN_ID")"; then
-    sync_apply lock-rejection --root "$DSH_MEMORY_ROOT" --operation-name sync --run-id "$RUN_ID" \
-      --error-code operation-in-progress >/dev/null 2>&1 || true
-    print -u2 -- "dsh-memory-sync: another sync operation is in progress"
-    exit 1
-  fi
-  LOCK_HELD=1
-  if [[ "$RETRY_FAILED" == "0" && -n "$CANDIDATE_DIGEST" ]]; then
-    retry_output="$(sync_apply retry-check --root "$DSH_MEMORY_ROOT" --candidate-digest "$CANDIDATE_DIGEST" \
-      --sync-policy-version "$SYNC_POLICY_VERSION" --cooldown-seconds "$RETRY_COOLDOWN_SECONDS")"
-    if [[ "$(printf '%s' "$retry_output" | "$PYTHON_BIN" -c 'import json,sys; print(str(json.load(sys.stdin).get("value", {}).get("suppressed", False)).lower())')" == "true" ]]; then
-      retry_error="$(printf '%s' "$retry_output" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin).get("value", {}).get("error_code") or "sync-failed")')"
-      sync_apply journal --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
-        --status skipped-retry --started-at "$STARTED_AT" --candidate-sessions "$CANDIDATE_SESSIONS" \
-        --processed-sessions 0 --skipped-sessions "$CANDIDATE_SESSIONS" --changed-paths "" \
-        --error-code "$retry_error" --phase retry --candidate-digest "$CANDIDATE_DIGEST" \
-        --sync-policy-version "$SYNC_POLICY_VERSION" --suppress-last-run >/dev/null 2>&1 || true
-      print -u2 -- "dsh-memory-sync: retry suppressed for $CANDIDATE_DIGEST"
-      exit 0
-    fi
-  fi
-  # A previous sync may have been interrupted (dead pid + active-run record).
-  # Recover it into the journal before starting a fresh run.
-  recover_output="$(sync_apply recover-active --root "$DSH_MEMORY_ROOT")" || {
-    print -u2 -- "dsh-memory-sync: active run recovery failed: $recover_output"
-    exit 1
-  }
-  recovered="$(printf '%s' "$recover_output" | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["value"]["recovered"])')"
-  if [[ "$recovered" == "True" ]]; then
-    progress "recovered an interrupted run; see the run journal."
-  fi
-  sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
-    --phase staging --started-at "$STARTED_AT" >/dev/null
+lock_output=""
+if ! lock_output="$(sync_apply acquire-lock --root "$DSH_MEMORY_ROOT" --operation-name sync --run-id "$RUN_ID")"; then
+  sync_apply lock-rejection --root "$DSH_MEMORY_ROOT" --operation-name sync --run-id "$RUN_ID" \
+    --error-code operation-in-progress >/dev/null 2>&1 || true
+  print -u2 -- "dsh-memory-sync: another sync operation is in progress"
+  exit 1
 fi
+LOCK_HELD=1
+if [[ "$RETRY_FAILED" == "0" && -n "$CANDIDATE_DIGEST" ]]; then
+  retry_output="$(sync_apply retry-check --root "$DSH_MEMORY_ROOT" --candidate-digest "$CANDIDATE_DIGEST" \
+    --sync-policy-version "$SYNC_POLICY_VERSION" --cooldown-seconds "$RETRY_COOLDOWN_SECONDS")"
+  if [[ "$(printf '%s' "$retry_output" | "$PYTHON_BIN" -c 'import json,sys; print(str(json.load(sys.stdin).get("value", {}).get("suppressed", False)).lower())')" == "true" ]]; then
+    retry_error="$(printf '%s' "$retry_output" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin).get("value", {}).get("error_code") or "sync-failed")')"
+    sync_apply journal --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
+      --status skipped-retry --started-at "$STARTED_AT" --candidate-sessions "$CANDIDATE_SESSIONS" \
+      --processed-sessions 0 --skipped-sessions "$CANDIDATE_SESSIONS" --changed-paths "" \
+      --error-code "$retry_error" --phase retry --candidate-digest "$CANDIDATE_DIGEST" \
+      --sync-policy-version "$SYNC_POLICY_VERSION" --suppress-last-run >/dev/null 2>&1 || true
+    print -u2 -- "dsh-memory-sync: retry suppressed for $CANDIDATE_DIGEST"
+    exit 0
+  fi
+fi
+# A previous sync may have been interrupted (dead pid + active-run record).
+# Recover it into the journal before starting a fresh run.
+recover_output="$(sync_apply recover-active --root "$DSH_MEMORY_ROOT")" || {
+  print -u2 -- "dsh-memory-sync: active run recovery failed: $recover_output"
+  exit 1
+}
+recovered="$(printf '%s' "$recover_output" | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["value"]["recovered"])')"
+if [[ "$recovered" == "True" ]]; then
+  progress "recovered an interrupted run; see the run journal."
+fi
+sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
+  --phase staging --started-at "$STARTED_AT" >/dev/null
 
 if [[ -n "$CANDIDATE_LIMIT_ERROR" ]]; then
-  if [[ "$DRY_RUN" == "1" ]]; then
-    if [[ "$JSON_OUTPUT" == "1" ]]; then
-      printf '{"ok":false,"dryRun":true,"error":{"code":"%s"}}\n' "$CANDIDATE_LIMIT_ERROR"
-    else
-      print -u2 -- "dsh-memory-sync: candidate batch rejected: $CANDIDATE_LIMIT_ERROR"
-    fi
-  else
-    write_failure_record "$CANDIDATE_LIMIT_ERROR" candidate-scan
-    print -u2 -- "dsh-memory-sync: candidate batch rejected: $CANDIDATE_LIMIT_ERROR"
-  fi
+  write_failure_record "$CANDIDATE_LIMIT_ERROR" candidate-scan
+  print -u2 -- "dsh-memory-sync: candidate batch rejected: $CANDIDATE_LIMIT_ERROR"
   exit 1
 fi
 
@@ -641,10 +692,8 @@ fi
 PROCESSED_SESSIONS="$CANDIDATE_SESSIONS"
 
 # --- Host-side verification and apply ---
-if [[ "$DRY_RUN" == "0" ]]; then
-  sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
-    --phase validating --started-at "$STARTED_AT" >/dev/null
-fi
+sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
+  --phase validating --started-at "$STARTED_AT" >/dev/null
 difference=""
 if ! difference="$(sync_apply diff --staging "$STAGING" --manifest "$MANIFEST" --run-id "$RUN_ID")"; then
   diff_error="$(json_error_code "$difference")"
@@ -662,21 +711,14 @@ diff_bytes="$(printf '%s' "$difference" | /usr/bin/python3 -c 'import json,sys; 
 json_list() { [[ -z "$1" ]] && printf '[]' || printf '[%s]' "$(printf '%s' "$1" | /usr/bin/sed 's/\([^,]*\)/"\1"/g')"; }
 
 if [[ -z "$changed_paths" ]]; then
-  if [[ "$DRY_RUN" == "1" && "$JSON_OUTPUT" == "1" ]]; then
-    printf '{"ok":true,"dryRun":true,"candidateSessions":%s,"changedPaths":[],"message":"no changes"}\n' "$CANDIDATE_SESSIONS"
-  else
-    echo "dsh-memory-sync: no memory changes, nothing to apply."
-    if [[ "$DRY_RUN" == "1" ]]; then
-      echo "dsh-memory-sync: dry-run: no changes would be applied."
-    fi
-  fi
+  echo "dsh-memory-sync: no memory changes, nothing to apply."
   # Zero-change runs still advance the watermark and journal a no_change
   # record: every candidate was delivered to the model, so rescanning the
   # same window forever would only repeat paid model calls. The run did not
   # touch the live payload, so finalize commits only .sync + .last-sync.
   # Preview runs are excluded: preview mode is an operator-review tool and
   # stays non-journaling (see the preview contract comment near the end).
-  if [[ "$DRY_RUN" == "0" && "$PREVIEW_MODE" == "0" ]]; then
+  if [[ "$PREVIEW_MODE" == "0" ]]; then
     typeset -a FINALIZE_LAST_SYNC_ARGS
     FINALIZE_LAST_SYNC_ARGS=()
     [[ "$CANDIDATE_TRUNCATED" == "1" ]] || FINALIZE_LAST_SYNC_ARGS=(--last-sync "$START_TS")
@@ -709,17 +751,6 @@ if [[ -z "$changed_paths" ]]; then
   exit 0
 fi
 
-if [[ "$DRY_RUN" == "1" ]]; then
-  if [[ "$JSON_OUTPUT" == "1" ]]; then
-    printf '{"ok":true,"dryRun":true,"candidateSessions":%s,"changedPaths":%s,"added":%s,"modified":%s,"deleted":%s,"changedBytes":%s}\n' \
-      "$CANDIDATE_SESSIONS" "$(json_list "$changed_paths")" "$(json_list "$diff_added")" "$(json_list "$diff_modified")" "$(json_list "$diff_deleted")" "$diff_bytes"
-  else
-    echo "dsh-memory-sync: dry-run — would apply: $changed_paths"
-  fi
-  rm -rf -- "$STAGING_PARENT"
-  exit 0
-fi
-
 # --- Preview mode: stage the candidate diff under .sync/previews/<id> and
 # leave it pending. Nothing is applied, journaled, or committed here; the
 # model edit is captured so an operator can review and apply it later.
@@ -747,10 +778,8 @@ if [[ "$PREVIEW_MODE" == "1" ]]; then
   exit 0
 fi
 
-if [[ "$DRY_RUN" == "0" ]]; then
-  sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
-    --phase applying --started-at "$STARTED_AT" >/dev/null
-fi
+sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
+  --phase applying --started-at "$STARTED_AT" >/dev/null
 apply_result="$(sync_apply apply --root "$DSH_MEMORY_ROOT" --staging "$STAGING" --manifest "$MANIFEST" --run-id "$RUN_ID" --started-at "$STARTED_AT")" || {
   apply_error="$(json_error_code "$apply_result")"
   # Record the failure in the journal so the run is auditable even when the
@@ -766,10 +795,8 @@ apply_commit="$(printf '%s' "$apply_result" | /usr/bin/python3 -c 'import json,s
 
 # Journal the run and advance the watermark only after a successful apply.
 DURATION_MS=$(( ( $(date +%s) - START_TS ) * 1000 ))
-if [[ "$DRY_RUN" == "0" ]]; then
-  sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
-    --phase finalizing --started-at "$STARTED_AT" >/dev/null
-fi
+sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
+  --phase finalizing --started-at "$STARTED_AT" >/dev/null
 finalize_output=""
 typeset -a FINALIZE_LAST_SYNC_ARGS
 FINALIZE_LAST_SYNC_ARGS=()
@@ -799,11 +826,9 @@ fi
 write_pending_candidates
 sync_apply clear-failure-sentinel --root "$DSH_MEMORY_ROOT" >/dev/null 2>&1 || true
 
-if [[ "$DRY_RUN" == "0" ]]; then
-  sync_apply clear-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" >/dev/null 2>&1 || true
-  sync_apply release-lock --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" >/dev/null 2>&1 || true
-  LOCK_HELD=0
-fi
+sync_apply clear-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" >/dev/null 2>&1 || true
+sync_apply release-lock --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" >/dev/null 2>&1 || true
+LOCK_HELD=0
 
 echo "dsh-memory-sync: applied $changed_paths (recovery $recovery_commit, apply $apply_commit, run $RUN_ID)."
 rm -rf -- "$STAGING_PARENT"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-git-memory",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-git-memory",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "workspaces": [
         "packages/dsh-memory",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-git-memory",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": false,
   "description": "A local Git-backed long-term memory bundle for DeepSeek Harness",
   "type": "module",

--- a/packages/dsh-git-memory/client/client.js
+++ b/packages/dsh-git-memory/client/client.js
@@ -306,6 +306,15 @@ window.__ModuleLoader__.load({
               }
             };
             const unavailable = snapshot.status === "error" ? `长期记忆服务未就绪，暂不能修改（${snapshot.error ?? "settings-unavailable"}）` : snapshot.status === "loading" ? "正在读取长期记忆设置…" : "长期记忆设置不可写";
+            // Metadata anomalies are a data-quality warning surfaced separately
+            // from the repository health line; they never merge into recovery
+            // states on the host side either.
+            const metadataAnomaly = repository?.value && repository.value.metadataValid === false
+              ? {
+                  count: repository.value.invalidMetadataCount ?? 0,
+                  paths: (repository.value.invalidMetadata ?? []).slice(0, 5).map((entry) => entry.path),
+                }
+              : null;
             const repositoryStatus = repository?.error
               ? { tone: "danger", text: `记忆库不可用：${repository.error}`, error: true }
               : repository?.value
@@ -347,6 +356,14 @@ window.__ModuleLoader__.load({
                       jsx.jsx("span", { className: `dshmu_dot dshmu_dot--${repositoryStatus.tone}`, "aria-hidden": "true" }),
                       jsx.jsx("span", { children: repositoryStatus.text }),
                     ] }),
+              ] }) }) }),
+              metadataAnomaly !== null && jsx.jsx("section", { className: "dshmu_row", "aria-label": "记忆数据格式异常", children: jsx.jsx("div", { className: "dshmu_head dshmu_head--static", children: jsx.jsxs("div", { className: "dshmu_headMain", children: [
+                jsx.jsx("div", { className: "dshmu_title", children: "记忆数据格式异常" }),
+                jsx.jsxs("div", { className: "dshmu_statusLine dshmu_statusLine--error", children: [
+                  jsx.jsx("span", { className: "dshmu_dot dshmu_dot--warning", "aria-hidden": "true" }),
+                  jsx.jsx("span", { children: `${metadataAnomaly.count} 条记录的元数据无效；这些记录已从检索中排除，不影响其余记忆的使用与同步` }),
+                ] }),
+                metadataAnomaly.paths.length > 0 && jsx.jsx("span", { className: "dshmu_desc", children: metadataAnomaly.paths.join("、") }),
               ] }) }) }),
               repository !== null && jsx.jsxs("section", { className: "dshmu_row", "aria-label": "最近同步", onKeyDown: rowKeyDown("sync"), children: [
                 lastRun === null

--- a/packages/dsh-git-memory/lib/index.js
+++ b/packages/dsh-git-memory/lib/index.js
@@ -1,6 +1,7 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { homedir, tmpdir } from "node:os";
+import { statSync, watchFile, unwatchFile } from "node:fs";
 import { copyFile, lstat, mkdir, mkdtemp, readFile, realpath, rm, rmdir, unlink, writeFile } from "node:fs/promises";
 import { join, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,7 +20,7 @@ import {
   releaseOperationLock,
   writeActiveRun,
 } from "./operation-lock.js";
-import { parseFrontMatter, isExpired, topicKey } from "./memory-metadata.js";
+import { parseFrontMatter, isExpired, topicKey, auditRecords, AUDIT_INVALID_METADATA_LIMIT, MetadataError } from "./memory-metadata.js";
 import { legacyId, legacyRecordSummary, migratedContent, scanLegacyRecords } from "./legacy-migration.js";
 import { contentHashOf, formatCitation, readUsage, recordUsage, sortByUsage, usageMetadata } from "./memory-usage.js";
 import { SyncTransaction } from "./sync-transaction.js";
@@ -41,24 +42,38 @@ const PYTHON_CANDIDATES = Object.freeze([
   "python3",
 ].filter(Boolean));
 const Config = z.object({ enabled: z.boolean().default(true) });
+// Single-writer contract: ordinary sessions treat the memory repository as
+// read-only. Persistence happens exclusively through the periodic
+// transactional sync (dsh-memory-sync), which stages model output, verifies
+// it host-side, and commits it. No session ever runs git or writes to the
+// live repository directly.
 const MEMORY_SECTION = `长期记忆已开启（DPSK 专属仓库 ${DEFAULT_MEMORY_ROOT}，git 版本化；操作手册见 memory 技能）。
 
 自动行为，用户无需提醒：
 1. 每个任务动手前：先读下方 <summary_snapshot>（summary.md 的启动快照），需要细节时用 memory_search / memory_context 工具或 grep handbook/ 检索；命中则遵循，无命中直接开始，不要向用户询问"要不要回忆"。
-2. 完成重要任务或会话收尾时：自动用子代理执行记忆提取（extract → rollouts/）与整合（consolidate → handbook/ 与 summary.md），随后在仓库内 git add -A && git commit。
-3. 用户纠正偏好或告知新约定时：立即更新对应记忆条目。
+2. 普通会话对记忆库只读：不要直接写记忆文件，不要执行任何 git 命令。若本会话产生了值得沉淀的结论，把它作为记忆请求记录在自己的回复或会话中（说明建议归入 handbook/ 或 rollouts/ 的要点）；周期性事务同步（dsh-memory-sync）会在后台完成提取、整合与提交。
+3. 用户纠正偏好或告知新约定时：按第 2 条记录记忆请求；不要当场改写记忆条目。
 
 硬规则：只存证据化结论；禁存凭据（写入 [REDACTED]）；原始会话日志只读；宁缺毋滥。
 `;
 
 export const SUMMARY_BUDGET_BYTES = 12 * 1024;
 const SUMMARY_INJECT_MAX_BYTES = SUMMARY_BUDGET_BYTES;
+// Prompt freshness: the injected summary snapshot must track edits to
+// summary.md without waiting for a settings change. The host polls the file
+// every few seconds; an mtime/size change triggers one debounced async
+// refresh. While the file is briefly missing or unreadable the previous
+// valid snapshot is retained — the prompt is never cleared by a transient
+// read failure.
+let lastSummarySnapshot = null;
 async function buildMemorySectionText() {
   let summary;
   try {
     summary = await readFile(join(DEFAULT_MEMORY_ROOT, "summary.md"), "utf8");
+    lastSummarySnapshot = summary;
   } catch {
-    return MEMORY_SECTION;
+    if (lastSummarySnapshot === null) return MEMORY_SECTION;
+    summary = lastSummarySnapshot;
   }
   const bounded = boundedContextBody(summary, SUMMARY_INJECT_MAX_BYTES);
   const note = bounded.truncated
@@ -69,6 +84,36 @@ async function buildMemorySectionText() {
 <summary_snapshot>
 ${bounded.content}${note}
 </summary_snapshot>`;
+}
+
+const SUMMARY_WATCH_INTERVAL_MS = 5000;
+const SUMMARY_REFRESH_DEBOUNCE_MS = 1000;
+/** Poll summary.md and invoke onChange (debounced) after mtime/size changes. */
+function startSummaryWatcher(onChange) {
+  const summaryPath = join(DEFAULT_MEMORY_ROOT, "summary.md");
+  let lastSeen = null;
+  try {
+    const stat = statSync(summaryPath);
+    lastSeen = { mtimeMs: stat.mtimeMs, size: stat.size };
+  } catch {}
+  let debounceTimer = null;
+  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS }, (current) => {
+    // A zeroed stat means the file is temporarily gone; the snapshot
+    // retention in buildMemorySectionText covers it, so do not refresh.
+    if (!current || (current.size === 0 && current.mtimeMs === 0)) return;
+    if (lastSeen && current.mtimeMs === lastSeen.mtimeMs && current.size === lastSeen.size) return;
+    lastSeen = { mtimeMs: current.mtimeMs, size: current.size };
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      try { onChange(); } catch {}
+    }, SUMMARY_REFRESH_DEBOUNCE_MS);
+  });
+  return () => {
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = null;
+    unwatchFile(summaryPath);
+  };
 }
 
 export const name = "dsh-memory";
@@ -300,6 +345,7 @@ export class MemoryRepository {
       const { dataFileCount } = await safeClear(root, "inspect");
       const targetDirty = (await this.git(["status", "--porcelain", "--", ...TARGETS])).stdout.trim().length > 0;
       const { legacyFileCount, pendingMigration } = await this.metadataStats(root);
+      const audit = await this.metadataAudit(root);
       const lastRun = await this.readLastRun(root);
       const retrySuppressed = await this.readRetrySuppressed(root);
       const summaryBytes = await this.summaryBytes(root);
@@ -314,6 +360,10 @@ export class MemoryRepository {
         schemaVersion: 1,
         legacyFileCount,
         pendingMigration,
+        metadataValid: audit.metadataValid,
+        validMetadataCount: audit.validMetadataCount,
+        invalidMetadataCount: audit.invalidMetadataCount,
+        invalidMetadata: audit.invalidMetadata,
         lastRun,
         retrySuppressed,
         summaryBytes,
@@ -356,6 +406,7 @@ export class MemoryRepository {
       const summaryBytes = await this.summaryBytes(root);
       const failureSentinel = await this.readFailureSentinel(root);
       const finalizeFailure = await this.readFinalizeFailure(root);
+      const audit = await this.metadataAudit(root);
       const interruptedRun = activeState === "interrupted"
         ? activeRun
         : (await this.readLastRun(root))?.status === "interrupted" ? await this.readLastRun(root) : null;
@@ -371,6 +422,10 @@ export class MemoryRepository {
         finalizeFailure,
         retrySuppressed,
         payloadDirty,
+        metadataValid: audit.metadataValid,
+        validMetadataCount: audit.validMetadataCount,
+        invalidMetadataCount: audit.invalidMetadataCount,
+        invalidMetadata: audit.invalidMetadata,
         operationLock: operationLock === null ? null : {
           operation: operationLock.operation ?? null,
           pid: operationLock.pid ?? null,
@@ -383,6 +438,8 @@ export class MemoryRepository {
         pendingPreview: previews[0] ?? null,
         pendingPreviewCount: previews.length,
         journalReadable,
+        // Metadata anomalies are a data-quality warning, not a recovery
+        // blocker: reads and the periodic sync keep working around them.
         needsManualRecovery: payloadDirty || activeState === "interrupted" || interruptedRun !== null || !journalReadable
           || summaryBytes > SUMMARY_BUDGET_BYTES || (failureSentinel?.consecutive_failures ?? 0) >= 3
           || finalizeFailure !== null,
@@ -404,6 +461,27 @@ export class MemoryRepository {
     } catch {
       return { legacyFileCount: 0, pendingMigration: false };
     }
+  }
+
+  /** Record-shaped payload files eligible for the metadata audit. */
+  async recordFiles(root) {
+    return (await this.payloadFiles(root)).filter((file) => file !== "summary.md" && /\.md$/.test(file));
+  }
+
+  /**
+   * Shared metadata audit (report-only). Structured records are validated
+   * against schema v1; duplicate ids and unreadable files are reported.
+   * Metadata anomalies never block reads here and are deliberately not part
+   * of needsManualRecovery — the UI surfaces them as a separate warning.
+   */
+  async metadataAudit(root) {
+    const files = await this.recordFiles(root);
+    const records = [];
+    for (const file of files) {
+      const content = await readFileSafe(join(root, file), "utf8").catch(() => null);
+      records.push({ path: file, content });
+    }
+    return auditRecords(records);
   }
 
   async summaryBytes(root) {
@@ -768,7 +846,7 @@ export class MemoryRepository {
     }
   }
 
-  async collectSearchResults(root, query, includeArchive = false, usage = undefined) {
+  async collectSearchResults(root, query, includeArchive = false, usage = undefined, warnings = undefined) {
     const tokens = query.toLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 0);
     if (tokens.length === 0) throw memoryError("search-invalid-request");
     const results = [];
@@ -778,7 +856,14 @@ export class MemoryRepository {
       if (!includeArchive && file.startsWith("archive/")) continue;
       const content = await readFileSafe(join(root, file), "utf8").catch(() => "");
       let metadata = null;
-      try { metadata = parseFrontMatter(content, file); } catch { continue; }
+      try {
+        metadata = parseFrontMatter(content, file);
+      } catch (error) {
+        // Invalid metadata is excluded from results but never silently
+        // dropped: the caller returns it as a warning next to the results.
+        warnings?.push({ path: file, code: error instanceof MetadataError ? error.code : "invalid-metadata" });
+        continue;
+      }
       if (metadata !== null && isExpired(metadata)) continue;
       const recordId = metadata?.id ?? legacyId(file);
       const usageInfo = usageMetadata(file, usage);
@@ -835,9 +920,10 @@ export class MemoryRepository {
     try { root = await this.inspect(); } catch (error) { return failure(error?.memoryCode ?? "repo-unavailable"); }
     try {
       const usage = await readUsage(root);
-      const results = (await this.collectSearchResults(root, request.query, scope !== "active", usage))
+      const warnings = [];
+      const results = (await this.collectSearchResults(root, request.query, scope !== "active", usage, warnings))
         .filter((entry) => scope !== "archive" || entry.path.startsWith("archive/"));
-      return success({ query: request.query, count: results.length, results: results.slice(0, limit) });
+      return success({ query: request.query, count: results.length, results: results.slice(0, limit), warnings });
     } catch (error) {
       return failure(error?.memoryCode ?? "search-failed");
     }
@@ -859,9 +945,10 @@ export class MemoryRepository {
     try { root = await this.inspect(); } catch (error) { return failure(error?.memoryCode ?? "repo-unavailable"); }
     try {
       const usage = await readUsage(root);
+      const warnings = [];
       let candidates;
       if (hasQuery) {
-        candidates = sortByUsage(await this.collectSearchResults(root, request.query, scope !== "active", usage), usage).slice(0, limit);
+        candidates = sortByUsage(await this.collectSearchResults(root, request.query, scope !== "active", usage, warnings), usage).slice(0, limit);
       } else {
         candidates = [];
         for (const file of await this.payloadFiles(root)) {
@@ -870,7 +957,12 @@ export class MemoryRepository {
           if (scope === "archive" && !file.startsWith("archive/")) continue;
           const content = await readFileSafe(join(root, file), "utf8").catch(() => "");
           let metadata = null;
-          try { metadata = parseFrontMatter(content, file); } catch { continue; }
+          try {
+            metadata = parseFrontMatter(content, file);
+          } catch (error) {
+            warnings?.push({ path: file, code: error instanceof MetadataError ? error.code : "invalid-metadata" });
+            continue;
+          }
           if (metadata !== null && isExpired(metadata)) continue;
           const recordId = metadata?.id ?? legacyId(file);
           candidates.push({
@@ -915,6 +1007,7 @@ export class MemoryRepository {
         query: hasQuery ? request.query : null,
         count: records.length,
         records,
+        warnings,
       });
     } catch (error) {
       return failure(error?.memoryCode ?? "context-failed");
@@ -1220,6 +1313,11 @@ export function apply(ctx, entry) {
     };
     refreshPrompt = refresh;
     refresh();
-    promptCtx.effect(() => () => { if (refreshPrompt === refresh) refreshPrompt = () => {}; disposeSection?.(); }, "dsh-memory: section cleanup");
+    const stopSummaryWatcher = startSummaryWatcher(refresh);
+    promptCtx.effect(() => () => {
+      stopSummaryWatcher();
+      if (refreshPrompt === refresh) refreshPrompt = () => {};
+      disposeSection?.();
+    }, "dsh-memory: section cleanup");
   });
 }

--- a/packages/dsh-git-memory/lib/index.js
+++ b/packages/dsh-git-memory/lib/index.js
@@ -97,7 +97,7 @@ function startSummaryWatcher(onChange) {
     lastSeen = { mtimeMs: stat.mtimeMs, size: stat.size };
   } catch {}
   let debounceTimer = null;
-  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS }, (current) => {
+  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS, persistent: false }, (current) => {
     // A zeroed stat means the file is temporarily gone; the snapshot
     // retention in buildMemorySectionText covers it, so do not refresh.
     if (!current || (current.size === 0 && current.mtimeMs === 0)) return;

--- a/packages/dsh-git-memory/lib/memory-metadata.js
+++ b/packages/dsh-git-memory/lib/memory-metadata.js
@@ -105,6 +105,12 @@ function parseBlock(block) {
     const key = line.slice(0, colon).trim();
     const value = line.slice(colon + 1).trim();
     if (key === "") throw new MetadataError("invalid-metadata", "front matter has an empty key");
+    // Canonical records use block lists (tags:\n  - item). Flow-style
+    // collections are rejected with a stable code so the staging validator and
+    // the metadata audit report the same, actionable diagnosis.
+    if ((value.startsWith("[") && value !== "[]") || (value.startsWith("{") && value !== "{}")) {
+      throw new MetadataError("flow-style-metadata", `${key} must use a canonical block list, not a flow collection`);
+    }
     currentKey = key;
     if (value === "" || value.startsWith("|") || value.startsWith(">")) {
       // A nested mapping or block scalar is not part of the record contract.
@@ -277,4 +283,77 @@ export function resolveTopicConflict(records, now = Date.now()) {
     if (dateDiff !== 0) return dateDiff;
     return String(left.id).localeCompare(String(right.id));
   })[0];
+}
+
+export const AUDIT_INVALID_METADATA_LIMIT = 20;
+
+/**
+ * Shared metadata audit over structured records (schema_version 1).
+ *
+ * Scans every record-shaped payload document and reports:
+ *   - per-file validation failures (schema, fields, duplicate ids);
+ *   - legacy records (no front matter) which are counted but never invalid;
+ *   - duplicate structured ids across the corpus.
+ *
+ * The audit is report-only: callers decide whether invalid metadata blocks a
+ * write path (staging validation stays fail-closed) or only surfaces in
+ * status/health and search warnings. Legacy records grandfather as valid.
+ *
+ * @param {Array<{ path: string, content: string }>} records
+ * @returns {{ metadataValid: boolean, validMetadataCount: number, invalidMetadataCount: number, legacyMetadataCount: number, duplicateIdCount: number, invalidMetadata: Array<{ path: string, code: string }> }}
+ */
+export function auditRecords(records) {
+  let validCount = 0;
+  let legacyCount = 0;
+  const invalid = [];
+  let invalidCount = 0;
+  const seenIds = new Map();
+  let duplicateIdCount = 0;
+  for (const record of records) {
+    if (record.content === null || record.content === undefined) {
+      // The file could not be read at all; that is an invalid record, not a
+      // legacy one, so it surfaces in the audit instead of disappearing.
+      invalidCount += 1;
+      if (invalid.length < AUDIT_INVALID_METADATA_LIMIT) invalid.push({ path: record.path, code: "unreadable" });
+      continue;
+    }
+    if (!hasRecordFrontMatter(record.content)) {
+      legacyCount += 1;
+      continue;
+    }
+    try {
+      const metadata = parseFrontMatter(record.content, record.path);
+      if (metadata === null) {
+        // Not a record path (defensive; callers pre-filter).
+        continue;
+      }
+      validCount += 1;
+      const first = seenIds.get(metadata.id);
+      if (first !== undefined) {
+        duplicateIdCount += 1;
+        invalidCount += 1;
+        if (invalid.length < AUDIT_INVALID_METADATA_LIMIT) {
+          invalid.push({ path: record.path, code: "duplicate-id" });
+        }
+      } else {
+        seenIds.set(metadata.id, record.path);
+      }
+    } catch (error) {
+      const code = error instanceof MetadataError ? error.code : "invalid-metadata";
+      invalidCount += 1;
+      if (invalid.length < AUDIT_INVALID_METADATA_LIMIT) invalid.push({ path: record.path, code });
+    }
+  }
+  return {
+    metadataValid: invalidCount === 0,
+    validMetadataCount: validCount,
+    invalidMetadataCount: invalidCount,
+    legacyMetadataCount: legacyCount,
+    duplicateIdCount,
+    invalidMetadata: invalid,
+  };
+}
+
+function hasRecordFrontMatter(content) {
+  return content.startsWith("---\n") || content.startsWith("---\r\n");
 }

--- a/packages/dsh-memory-ui/lib/client.js
+++ b/packages/dsh-memory-ui/lib/client.js
@@ -306,6 +306,15 @@ window.__ModuleLoader__.load({
               }
             };
             const unavailable = snapshot.status === "error" ? `长期记忆服务未就绪，暂不能修改（${snapshot.error ?? "settings-unavailable"}）` : snapshot.status === "loading" ? "正在读取长期记忆设置…" : "长期记忆设置不可写";
+            // Metadata anomalies are a data-quality warning surfaced separately
+            // from the repository health line; they never merge into recovery
+            // states on the host side either.
+            const metadataAnomaly = repository?.value && repository.value.metadataValid === false
+              ? {
+                  count: repository.value.invalidMetadataCount ?? 0,
+                  paths: (repository.value.invalidMetadata ?? []).slice(0, 5).map((entry) => entry.path),
+                }
+              : null;
             const repositoryStatus = repository?.error
               ? { tone: "danger", text: `记忆库不可用：${repository.error}`, error: true }
               : repository?.value
@@ -347,6 +356,14 @@ window.__ModuleLoader__.load({
                       jsx.jsx("span", { className: `dshmu_dot dshmu_dot--${repositoryStatus.tone}`, "aria-hidden": "true" }),
                       jsx.jsx("span", { children: repositoryStatus.text }),
                     ] }),
+              ] }) }) }),
+              metadataAnomaly !== null && jsx.jsx("section", { className: "dshmu_row", "aria-label": "记忆数据格式异常", children: jsx.jsx("div", { className: "dshmu_head dshmu_head--static", children: jsx.jsxs("div", { className: "dshmu_headMain", children: [
+                jsx.jsx("div", { className: "dshmu_title", children: "记忆数据格式异常" }),
+                jsx.jsxs("div", { className: "dshmu_statusLine dshmu_statusLine--error", children: [
+                  jsx.jsx("span", { className: "dshmu_dot dshmu_dot--warning", "aria-hidden": "true" }),
+                  jsx.jsx("span", { children: `${metadataAnomaly.count} 条记录的元数据无效；这些记录已从检索中排除，不影响其余记忆的使用与同步` }),
+                ] }),
+                metadataAnomaly.paths.length > 0 && jsx.jsx("span", { className: "dshmu_desc", children: metadataAnomaly.paths.join("、") }),
               ] }) }) }),
               repository !== null && jsx.jsxs("section", { className: "dshmu_row", "aria-label": "最近同步", onKeyDown: rowKeyDown("sync"), children: [
                 lastRun === null

--- a/packages/dsh-memory-ui/package.json
+++ b/packages/dsh-memory-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory-ui",
-  "version": "0.8.1",
+  "version": "0.8.3",
   "private": true,
   "description": "Settings UI for DSH local long-term memory",
   "type": "module",

--- a/packages/dsh-memory/lib/index.js
+++ b/packages/dsh-memory/lib/index.js
@@ -1,6 +1,7 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { homedir, tmpdir } from "node:os";
+import { statSync, watchFile, unwatchFile } from "node:fs";
 import { copyFile, lstat, mkdir, mkdtemp, readFile, realpath, rm, rmdir, unlink, writeFile } from "node:fs/promises";
 import { join, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,7 +20,7 @@ import {
   releaseOperationLock,
   writeActiveRun,
 } from "./operation-lock.js";
-import { parseFrontMatter, isExpired, topicKey } from "./memory-metadata.js";
+import { parseFrontMatter, isExpired, topicKey, auditRecords, AUDIT_INVALID_METADATA_LIMIT, MetadataError } from "./memory-metadata.js";
 import { legacyId, legacyRecordSummary, migratedContent, scanLegacyRecords } from "./legacy-migration.js";
 import { contentHashOf, formatCitation, readUsage, recordUsage, sortByUsage, usageMetadata } from "./memory-usage.js";
 import { SyncTransaction } from "./sync-transaction.js";
@@ -41,24 +42,38 @@ const PYTHON_CANDIDATES = Object.freeze([
   "python3",
 ].filter(Boolean));
 const Config = z.object({ enabled: z.boolean().default(true) });
+// Single-writer contract: ordinary sessions treat the memory repository as
+// read-only. Persistence happens exclusively through the periodic
+// transactional sync (dsh-memory-sync), which stages model output, verifies
+// it host-side, and commits it. No session ever runs git or writes to the
+// live repository directly.
 const MEMORY_SECTION = `长期记忆已开启（DPSK 专属仓库 ${DEFAULT_MEMORY_ROOT}，git 版本化；操作手册见 memory 技能）。
 
 自动行为，用户无需提醒：
 1. 每个任务动手前：先读下方 <summary_snapshot>（summary.md 的启动快照），需要细节时用 memory_search / memory_context 工具或 grep handbook/ 检索；命中则遵循，无命中直接开始，不要向用户询问"要不要回忆"。
-2. 完成重要任务或会话收尾时：自动用子代理执行记忆提取（extract → rollouts/）与整合（consolidate → handbook/ 与 summary.md），随后在仓库内 git add -A && git commit。
-3. 用户纠正偏好或告知新约定时：立即更新对应记忆条目。
+2. 普通会话对记忆库只读：不要直接写记忆文件，不要执行任何 git 命令。若本会话产生了值得沉淀的结论，把它作为记忆请求记录在自己的回复或会话中（说明建议归入 handbook/ 或 rollouts/ 的要点）；周期性事务同步（dsh-memory-sync）会在后台完成提取、整合与提交。
+3. 用户纠正偏好或告知新约定时：按第 2 条记录记忆请求；不要当场改写记忆条目。
 
 硬规则：只存证据化结论；禁存凭据（写入 [REDACTED]）；原始会话日志只读；宁缺毋滥。
 `;
 
 export const SUMMARY_BUDGET_BYTES = 12 * 1024;
 const SUMMARY_INJECT_MAX_BYTES = SUMMARY_BUDGET_BYTES;
+// Prompt freshness: the injected summary snapshot must track edits to
+// summary.md without waiting for a settings change. The host polls the file
+// every few seconds; an mtime/size change triggers one debounced async
+// refresh. While the file is briefly missing or unreadable the previous
+// valid snapshot is retained — the prompt is never cleared by a transient
+// read failure.
+let lastSummarySnapshot = null;
 async function buildMemorySectionText() {
   let summary;
   try {
     summary = await readFile(join(DEFAULT_MEMORY_ROOT, "summary.md"), "utf8");
+    lastSummarySnapshot = summary;
   } catch {
-    return MEMORY_SECTION;
+    if (lastSummarySnapshot === null) return MEMORY_SECTION;
+    summary = lastSummarySnapshot;
   }
   const bounded = boundedContextBody(summary, SUMMARY_INJECT_MAX_BYTES);
   const note = bounded.truncated
@@ -69,6 +84,36 @@ async function buildMemorySectionText() {
 <summary_snapshot>
 ${bounded.content}${note}
 </summary_snapshot>`;
+}
+
+const SUMMARY_WATCH_INTERVAL_MS = 5000;
+const SUMMARY_REFRESH_DEBOUNCE_MS = 1000;
+/** Poll summary.md and invoke onChange (debounced) after mtime/size changes. */
+function startSummaryWatcher(onChange) {
+  const summaryPath = join(DEFAULT_MEMORY_ROOT, "summary.md");
+  let lastSeen = null;
+  try {
+    const stat = statSync(summaryPath);
+    lastSeen = { mtimeMs: stat.mtimeMs, size: stat.size };
+  } catch {}
+  let debounceTimer = null;
+  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS }, (current) => {
+    // A zeroed stat means the file is temporarily gone; the snapshot
+    // retention in buildMemorySectionText covers it, so do not refresh.
+    if (!current || (current.size === 0 && current.mtimeMs === 0)) return;
+    if (lastSeen && current.mtimeMs === lastSeen.mtimeMs && current.size === lastSeen.size) return;
+    lastSeen = { mtimeMs: current.mtimeMs, size: current.size };
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      try { onChange(); } catch {}
+    }, SUMMARY_REFRESH_DEBOUNCE_MS);
+  });
+  return () => {
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = null;
+    unwatchFile(summaryPath);
+  };
 }
 
 export const name = "dsh-memory";
@@ -300,6 +345,7 @@ export class MemoryRepository {
       const { dataFileCount } = await safeClear(root, "inspect");
       const targetDirty = (await this.git(["status", "--porcelain", "--", ...TARGETS])).stdout.trim().length > 0;
       const { legacyFileCount, pendingMigration } = await this.metadataStats(root);
+      const audit = await this.metadataAudit(root);
       const lastRun = await this.readLastRun(root);
       const retrySuppressed = await this.readRetrySuppressed(root);
       const summaryBytes = await this.summaryBytes(root);
@@ -314,6 +360,10 @@ export class MemoryRepository {
         schemaVersion: 1,
         legacyFileCount,
         pendingMigration,
+        metadataValid: audit.metadataValid,
+        validMetadataCount: audit.validMetadataCount,
+        invalidMetadataCount: audit.invalidMetadataCount,
+        invalidMetadata: audit.invalidMetadata,
         lastRun,
         retrySuppressed,
         summaryBytes,
@@ -356,6 +406,7 @@ export class MemoryRepository {
       const summaryBytes = await this.summaryBytes(root);
       const failureSentinel = await this.readFailureSentinel(root);
       const finalizeFailure = await this.readFinalizeFailure(root);
+      const audit = await this.metadataAudit(root);
       const interruptedRun = activeState === "interrupted"
         ? activeRun
         : (await this.readLastRun(root))?.status === "interrupted" ? await this.readLastRun(root) : null;
@@ -371,6 +422,10 @@ export class MemoryRepository {
         finalizeFailure,
         retrySuppressed,
         payloadDirty,
+        metadataValid: audit.metadataValid,
+        validMetadataCount: audit.validMetadataCount,
+        invalidMetadataCount: audit.invalidMetadataCount,
+        invalidMetadata: audit.invalidMetadata,
         operationLock: operationLock === null ? null : {
           operation: operationLock.operation ?? null,
           pid: operationLock.pid ?? null,
@@ -383,6 +438,8 @@ export class MemoryRepository {
         pendingPreview: previews[0] ?? null,
         pendingPreviewCount: previews.length,
         journalReadable,
+        // Metadata anomalies are a data-quality warning, not a recovery
+        // blocker: reads and the periodic sync keep working around them.
         needsManualRecovery: payloadDirty || activeState === "interrupted" || interruptedRun !== null || !journalReadable
           || summaryBytes > SUMMARY_BUDGET_BYTES || (failureSentinel?.consecutive_failures ?? 0) >= 3
           || finalizeFailure !== null,
@@ -404,6 +461,27 @@ export class MemoryRepository {
     } catch {
       return { legacyFileCount: 0, pendingMigration: false };
     }
+  }
+
+  /** Record-shaped payload files eligible for the metadata audit. */
+  async recordFiles(root) {
+    return (await this.payloadFiles(root)).filter((file) => file !== "summary.md" && /\.md$/.test(file));
+  }
+
+  /**
+   * Shared metadata audit (report-only). Structured records are validated
+   * against schema v1; duplicate ids and unreadable files are reported.
+   * Metadata anomalies never block reads here and are deliberately not part
+   * of needsManualRecovery — the UI surfaces them as a separate warning.
+   */
+  async metadataAudit(root) {
+    const files = await this.recordFiles(root);
+    const records = [];
+    for (const file of files) {
+      const content = await readFileSafe(join(root, file), "utf8").catch(() => null);
+      records.push({ path: file, content });
+    }
+    return auditRecords(records);
   }
 
   async summaryBytes(root) {
@@ -768,7 +846,7 @@ export class MemoryRepository {
     }
   }
 
-  async collectSearchResults(root, query, includeArchive = false, usage = undefined) {
+  async collectSearchResults(root, query, includeArchive = false, usage = undefined, warnings = undefined) {
     const tokens = query.toLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 0);
     if (tokens.length === 0) throw memoryError("search-invalid-request");
     const results = [];
@@ -778,7 +856,14 @@ export class MemoryRepository {
       if (!includeArchive && file.startsWith("archive/")) continue;
       const content = await readFileSafe(join(root, file), "utf8").catch(() => "");
       let metadata = null;
-      try { metadata = parseFrontMatter(content, file); } catch { continue; }
+      try {
+        metadata = parseFrontMatter(content, file);
+      } catch (error) {
+        // Invalid metadata is excluded from results but never silently
+        // dropped: the caller returns it as a warning next to the results.
+        warnings?.push({ path: file, code: error instanceof MetadataError ? error.code : "invalid-metadata" });
+        continue;
+      }
       if (metadata !== null && isExpired(metadata)) continue;
       const recordId = metadata?.id ?? legacyId(file);
       const usageInfo = usageMetadata(file, usage);
@@ -835,9 +920,10 @@ export class MemoryRepository {
     try { root = await this.inspect(); } catch (error) { return failure(error?.memoryCode ?? "repo-unavailable"); }
     try {
       const usage = await readUsage(root);
-      const results = (await this.collectSearchResults(root, request.query, scope !== "active", usage))
+      const warnings = [];
+      const results = (await this.collectSearchResults(root, request.query, scope !== "active", usage, warnings))
         .filter((entry) => scope !== "archive" || entry.path.startsWith("archive/"));
-      return success({ query: request.query, count: results.length, results: results.slice(0, limit) });
+      return success({ query: request.query, count: results.length, results: results.slice(0, limit), warnings });
     } catch (error) {
       return failure(error?.memoryCode ?? "search-failed");
     }
@@ -859,9 +945,10 @@ export class MemoryRepository {
     try { root = await this.inspect(); } catch (error) { return failure(error?.memoryCode ?? "repo-unavailable"); }
     try {
       const usage = await readUsage(root);
+      const warnings = [];
       let candidates;
       if (hasQuery) {
-        candidates = sortByUsage(await this.collectSearchResults(root, request.query, scope !== "active", usage), usage).slice(0, limit);
+        candidates = sortByUsage(await this.collectSearchResults(root, request.query, scope !== "active", usage, warnings), usage).slice(0, limit);
       } else {
         candidates = [];
         for (const file of await this.payloadFiles(root)) {
@@ -870,7 +957,12 @@ export class MemoryRepository {
           if (scope === "archive" && !file.startsWith("archive/")) continue;
           const content = await readFileSafe(join(root, file), "utf8").catch(() => "");
           let metadata = null;
-          try { metadata = parseFrontMatter(content, file); } catch { continue; }
+          try {
+            metadata = parseFrontMatter(content, file);
+          } catch (error) {
+            warnings?.push({ path: file, code: error instanceof MetadataError ? error.code : "invalid-metadata" });
+            continue;
+          }
           if (metadata !== null && isExpired(metadata)) continue;
           const recordId = metadata?.id ?? legacyId(file);
           candidates.push({
@@ -915,6 +1007,7 @@ export class MemoryRepository {
         query: hasQuery ? request.query : null,
         count: records.length,
         records,
+        warnings,
       });
     } catch (error) {
       return failure(error?.memoryCode ?? "context-failed");
@@ -1220,6 +1313,11 @@ export function apply(ctx, entry) {
     };
     refreshPrompt = refresh;
     refresh();
-    promptCtx.effect(() => () => { if (refreshPrompt === refresh) refreshPrompt = () => {}; disposeSection?.(); }, "dsh-memory: section cleanup");
+    const stopSummaryWatcher = startSummaryWatcher(refresh);
+    promptCtx.effect(() => () => {
+      stopSummaryWatcher();
+      if (refreshPrompt === refresh) refreshPrompt = () => {};
+      disposeSection?.();
+    }, "dsh-memory: section cleanup");
   });
 }

--- a/packages/dsh-memory/lib/index.js
+++ b/packages/dsh-memory/lib/index.js
@@ -97,7 +97,7 @@ function startSummaryWatcher(onChange) {
     lastSeen = { mtimeMs: stat.mtimeMs, size: stat.size };
   } catch {}
   let debounceTimer = null;
-  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS }, (current) => {
+  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS, persistent: false }, (current) => {
     // A zeroed stat means the file is temporarily gone; the snapshot
     // retention in buildMemorySectionText covers it, so do not refresh.
     if (!current || (current.size === 0 && current.mtimeMs === 0)) return;

--- a/packages/dsh-memory/lib/memory-metadata.js
+++ b/packages/dsh-memory/lib/memory-metadata.js
@@ -105,6 +105,12 @@ function parseBlock(block) {
     const key = line.slice(0, colon).trim();
     const value = line.slice(colon + 1).trim();
     if (key === "") throw new MetadataError("invalid-metadata", "front matter has an empty key");
+    // Canonical records use block lists (tags:\n  - item). Flow-style
+    // collections are rejected with a stable code so the staging validator and
+    // the metadata audit report the same, actionable diagnosis.
+    if ((value.startsWith("[") && value !== "[]") || (value.startsWith("{") && value !== "{}")) {
+      throw new MetadataError("flow-style-metadata", `${key} must use a canonical block list, not a flow collection`);
+    }
     currentKey = key;
     if (value === "" || value.startsWith("|") || value.startsWith(">")) {
       // A nested mapping or block scalar is not part of the record contract.
@@ -277,4 +283,77 @@ export function resolveTopicConflict(records, now = Date.now()) {
     if (dateDiff !== 0) return dateDiff;
     return String(left.id).localeCompare(String(right.id));
   })[0];
+}
+
+export const AUDIT_INVALID_METADATA_LIMIT = 20;
+
+/**
+ * Shared metadata audit over structured records (schema_version 1).
+ *
+ * Scans every record-shaped payload document and reports:
+ *   - per-file validation failures (schema, fields, duplicate ids);
+ *   - legacy records (no front matter) which are counted but never invalid;
+ *   - duplicate structured ids across the corpus.
+ *
+ * The audit is report-only: callers decide whether invalid metadata blocks a
+ * write path (staging validation stays fail-closed) or only surfaces in
+ * status/health and search warnings. Legacy records grandfather as valid.
+ *
+ * @param {Array<{ path: string, content: string }>} records
+ * @returns {{ metadataValid: boolean, validMetadataCount: number, invalidMetadataCount: number, legacyMetadataCount: number, duplicateIdCount: number, invalidMetadata: Array<{ path: string, code: string }> }}
+ */
+export function auditRecords(records) {
+  let validCount = 0;
+  let legacyCount = 0;
+  const invalid = [];
+  let invalidCount = 0;
+  const seenIds = new Map();
+  let duplicateIdCount = 0;
+  for (const record of records) {
+    if (record.content === null || record.content === undefined) {
+      // The file could not be read at all; that is an invalid record, not a
+      // legacy one, so it surfaces in the audit instead of disappearing.
+      invalidCount += 1;
+      if (invalid.length < AUDIT_INVALID_METADATA_LIMIT) invalid.push({ path: record.path, code: "unreadable" });
+      continue;
+    }
+    if (!hasRecordFrontMatter(record.content)) {
+      legacyCount += 1;
+      continue;
+    }
+    try {
+      const metadata = parseFrontMatter(record.content, record.path);
+      if (metadata === null) {
+        // Not a record path (defensive; callers pre-filter).
+        continue;
+      }
+      validCount += 1;
+      const first = seenIds.get(metadata.id);
+      if (first !== undefined) {
+        duplicateIdCount += 1;
+        invalidCount += 1;
+        if (invalid.length < AUDIT_INVALID_METADATA_LIMIT) {
+          invalid.push({ path: record.path, code: "duplicate-id" });
+        }
+      } else {
+        seenIds.set(metadata.id, record.path);
+      }
+    } catch (error) {
+      const code = error instanceof MetadataError ? error.code : "invalid-metadata";
+      invalidCount += 1;
+      if (invalid.length < AUDIT_INVALID_METADATA_LIMIT) invalid.push({ path: record.path, code });
+    }
+  }
+  return {
+    metadataValid: invalidCount === 0,
+    validMetadataCount: validCount,
+    invalidMetadataCount: invalidCount,
+    legacyMetadataCount: legacyCount,
+    duplicateIdCount,
+    invalidMetadata: invalid,
+  };
+}
+
+function hasRecordFrontMatter(content) {
+  return content.startsWith("---\n") || content.startsWith("---\r\n");
 }

--- a/packages/dsh-memory/package.json
+++ b/packages/dsh-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "description": "Automatic local long-term memory for DSH",
   "type": "module",

--- a/packages/dsh-memory/templates/README.md
+++ b/packages/dsh-memory/templates/README.md
@@ -31,8 +31,35 @@
 
 原始会话日志仍保留在本地 DSH 会话目录中，过滤器不会改写或删除源日志。若敏感值已经进入记忆 Git 历史，普通回退或删除当前文件不能保证彻底抹除；停止同步、轮换相关凭据，并按本机数据保留策略处理源日志和仓库历史。
 
+## 写入边界（单写者契约）
+
+普通会话对本仓库**只读**：不要直接写任何记忆文件，不要执行任何 git 命令。唯一写入路径是周期性事务同步 `dsh-memory-sync`：模型只在宿主准备的隔离 staging 副本中修改 `summary.md`、`handbook/`、`rollouts/`、`archive/`，退出后由宿主校验、提交并推进水位；本仓库的 README、`.sync/.gitignore` 和 `scripts/filter_session.py` 是宿主管理的只读模板，模型与 staging 都不得修改。
+
+会话中产生的记忆请求（建议沉淀的结论）记录在会话输出中即可，由后续同步负责落库。
+
+## 元数据规范
+
+新增或修改 handbook/ 与 rollouts/ 记录时必须携带 schema v1 front matter；列表字段（如 `tags`、`source_rollouts`）必须使用块列表，不允许行内流程写法：
+
+```yaml
+---
+schema_version: 1
+id: preference-response-language
+type: preference
+status: active
+confidence: high
+created_at: 2026-08-19
+updated_at: 2026-08-19
+tags:
+  - dsh-memory
+  - 检索
+source_rollouts:
+  - rollouts/2026-08-19-session-001.md
+---
+```
+
 ## 提炼与整合
 
 提炼时只保留：稳定用户偏好、最终方案与原因、失败模式、项目入口、可复现命令和明确的后续契约。无高信号时写 `NO_SIGNAL` 并跳过。
 
-整合时先比较新旧条目：冲突则覆盖、过时则移入 `archive/`、无变化则不制造噪声。`summary.md` 最终必须不超过 12 KiB；超出时压缩重复过程和细节，不得静默超出预算。完成后提交本仓库中的实际变更。
+整合时先比较新旧条目：冲突则覆盖、过时则移入 `archive/`、无变化则不制造噪声。`summary.md` 最终必须不超过 12 KiB；超出时压缩重复过程和细节，不得静默超出预算。不要执行 git、不要更新同步水位：宿主会在 staging 校验通过后代为提交。

--- a/tests/test_dsh_memory_init.sh
+++ b/tests/test_dsh_memory_init.sh
@@ -104,24 +104,67 @@ DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
 REFRESH_MEMORY_ROOT="$REFRESH_HOME/storages/memory"
 REFRESH_TEMPLATE="$FIXTURE_REPO/packages/dsh-memory/templates/scripts/filter_session.py"
 REFRESH_HELPER="$REFRESH_MEMORY_ROOT/scripts/filter_session.py"
+REFRESH_README_TEMPLATE="$FIXTURE_REPO/packages/dsh-memory/templates/README.md"
+REFRESH_README="$REFRESH_MEMORY_ROOT/README.md"
+REFRESH_GITIGNORE_TEMPLATE="$FIXTURE_REPO/packages/dsh-memory/templates/.sync/.gitignore"
+REFRESH_GITIGNORE="$REFRESH_MEMORY_ROOT/.sync/.gitignore"
 print -r -- '# refresh-marker-one' >> "$REFRESH_TEMPLATE"
 refresh_head_before="$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)"
 DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
 test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" != "$refresh_head_before"
-test "$(git -C "$REFRESH_MEMORY_ROOT" log -1 --format=%s)" = "Refresh helper scripts"
+test "$(git -C "$REFRESH_MEMORY_ROOT" log -1 --format=%s)" = "Refresh managed memory templates"
 test "$(git -C "$REFRESH_MEMORY_ROOT" diff-tree --no-commit-id --name-only -r HEAD)" = "scripts/filter_session.py"
 cmp -s "$REFRESH_TEMPLATE" "$REFRESH_HELPER"
 refresh_head_after="$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)"
 DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
 test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" = "$refresh_head_after"
 
+# All managed templates (README, .sync/.gitignore, helper) refresh in a
+# single "Refresh managed memory templates" commit listing exactly the
+# changed files.
+print -r -- '# refresh-readme-marker' >> "$REFRESH_README_TEMPLATE"
+print -r -- '# refresh-gitignore-marker' >> "$REFRESH_GITIGNORE_TEMPLATE"
+DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
+test "$(git -C "$REFRESH_MEMORY_ROOT" log -1 --format=%s)" = "Refresh managed memory templates"
+changed_files="$(git -C "$REFRESH_MEMORY_ROOT" diff-tree --no-commit-id --name-only -r HEAD | sort)"
+test "$changed_files" = "$(printf '.sync/.gitignore\nREADME.md')"
+cmp -s "$REFRESH_README_TEMPLATE" "$REFRESH_README"
+cmp -s "$REFRESH_GITIGNORE_TEMPLATE" "$REFRESH_GITIGNORE"
+refresh_head_after="$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)"
+DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
+test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" = "$refresh_head_after"
+
+# A dirty (uncommitted) managed template fails closed for every managed file.
 print -r -- '# uncommitted-helper-change' >> "$REFRESH_HELPER"
-print -r -- '# refresh-marker-two' >> "$REFRESH_TEMPLATE"
 if DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null 2>&1; then
   print -u2 -- "initializer overwrote a dirty helper"
   exit 1
 fi
 grep -q -- '# uncommitted-helper-change' "$REFRESH_HELPER"
+test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" = "$refresh_head_after"
+git -C "$REFRESH_MEMORY_ROOT" checkout -- scripts/filter_session.py
+
+print -r -- '# uncommitted-readme-change' >> "$REFRESH_README"
+if DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null 2>&1; then
+  print -u2 -- "initializer overwrote a dirty README"
+  exit 1
+fi
+grep -q -- '# uncommitted-readme-change' "$REFRESH_README"
+test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" = "$refresh_head_after"
+git -C "$REFRESH_MEMORY_ROOT" checkout -- README.md
+
+print -r -- '# uncommitted-gitignore-change' >> "$REFRESH_GITIGNORE"
+if DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null 2>&1; then
+  print -u2 -- "initializer overwrote a dirty .sync/.gitignore"
+  exit 1
+fi
+grep -q -- '# uncommitted-gitignore-change' "$REFRESH_GITIGNORE"
+test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" = "$refresh_head_after"
+git -C "$REFRESH_MEMORY_ROOT" checkout -- .sync/.gitignore
+
+# After reverting every dirty change, the initializer succeeds again and the
+# live copies match the (now stale) templates without a new commit.
+DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
 test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" = "$refresh_head_after"
 
 print "dsh-memory initializer tests passed"

--- a/tests/test_dsh_memory_marketplace.mjs
+++ b/tests/test_dsh_memory_marketplace.mjs
@@ -11,7 +11,7 @@ const manifest = JSON.parse(await readFile(join(project, "package.json"), "utf8"
 const patch = await readFile(join(project, "packages/dsh-git-memory/cordis.patch.yml"), "utf8");
 
 assert.equal(manifest.name, "dsh-git-memory");
-assert.equal(manifest.version, "0.8.2");
+assert.equal(manifest.version, "0.8.3");
 assert.notEqual(manifest.private, true);
 assert.equal(manifest.main, "./packages/dsh-git-memory/lib/index.js");
 assert.equal(manifest.exports["."], "./packages/dsh-git-memory/lib/index.js");

--- a/tests/test_dsh_memory_metadata.mjs
+++ b/tests/test_dsh_memory_metadata.mjs
@@ -8,6 +8,8 @@ import {
   topicKey,
   resolveTopicConflict,
   isExpired,
+  auditRecords,
+  AUDIT_INVALID_METADATA_LIMIT,
 } from "../packages/dsh-memory/lib/memory-metadata.js";
 
 const canonical = `---
@@ -168,6 +170,75 @@ body`, "handbook/project.md");
   assert.equal(isExpired({ expires_at: "2020-01-01" }), true);
   assert.equal(isExpired({ expires_at: "2999-01-01" }), false);
   assert.equal(isExpired({}), false);
+}
+
+{
+  // v0.8.3: flow-style collections are rejected with a stable code; empty
+  // flow collections and canonical block lists stay valid.
+  assert.throws(
+    () => parseFrontMatter("---\nschema_version: 1\nid: x\ntags: [a, b]\n---\n", "handbook/x.md"),
+    (error) => error instanceof MetadataError && error.code === "flow-style-metadata",
+  );
+  assert.throws(
+    () => parseFrontMatter("---\nschema_version: 1\nid: x\nsource_rollouts: {a: 1}\n---\n", "handbook/x.md"),
+    (error) => error instanceof MetadataError && error.code === "flow-style-metadata",
+  );
+  const emptyFlow = parseFrontMatter("---\nschema_version: 1\nid: x\ntags: []\n---\n", "handbook/x.md");
+  assert.deepEqual(emptyFlow.tags, []);
+  const blockList = parseFrontMatter("---\nschema_version: 1\nid: x\ntags:\n  - a\n  - b\n---\n", "handbook/x.md");
+  assert.deepEqual(blockList.tags, ["a", "b"]);
+}
+
+{
+  // v0.8.3: the shared metadata audit reports valid/legacy/invalid records,
+  // duplicate ids, and truncates the invalid list to the documented limit.
+  const valid = (id) => `---\nschema_version: 1\nid: ${id}\n---\n正文\n`;
+  const audit = auditRecords([
+    { path: "handbook/a.md", content: valid("rec-a") },
+    { path: "handbook/b.md", content: valid("rec-b") },
+    { path: "handbook/legacy.md", content: "# plain markdown\nlegacy record\n" },
+    { path: "handbook/bad.md", content: "---\nschema_version: 2\nid: rec-bad\n---\n" },
+    { path: "handbook/flow.md", content: "---\nschema_version: 1\nid: rec-flow\ntags: [x]\n---\n" },
+    { path: "handbook/gone.md", content: null },
+    { path: "handbook/dup.md", content: valid("rec-a") },
+  ]);
+  assert.equal(audit.metadataValid, false);
+  assert.equal(audit.validMetadataCount, 3); // rec-a, rec-b, dup
+  assert.equal(audit.legacyMetadataCount, 1);
+  assert.equal(audit.invalidMetadataCount, 4); // bad + flow + gone + dup
+  assert.equal(audit.duplicateIdCount, 1);
+  assert.ok(audit.invalidMetadata.length <= AUDIT_INVALID_METADATA_LIMIT);
+  const byPath = new Map(audit.invalidMetadata.map((entry) => [entry.path, entry.code]));
+  assert.equal(byPath.get("handbook/bad.md"), "invalid-schema-version");
+  assert.equal(byPath.get("handbook/flow.md"), "flow-style-metadata");
+  assert.equal(byPath.get("handbook/gone.md"), "unreadable");
+  assert.equal(byPath.get("handbook/dup.md"), "duplicate-id");
+}
+
+{
+  // v0.8.3: a fully valid corpus audits clean; legacy records grandfather.
+  const audit = auditRecords([
+    { path: "handbook/a.md", content: "---\nschema_version: 1\nid: rec-a\n---\n" },
+    { path: "handbook/legacy.md", content: "# plain markdown\n" },
+  ]);
+  assert.equal(audit.metadataValid, true);
+  assert.equal(audit.validMetadataCount, 1);
+  assert.equal(audit.invalidMetadataCount, 0);
+  assert.equal(audit.legacyMetadataCount, 1);
+  assert.deepEqual(audit.invalidMetadata, []);
+}
+
+{
+  // v0.8.3: the invalid list is truncated to AUDIT_INVALID_METADATA_LIMIT
+  // while the count reflects every invalid record.
+  const flood = [];
+  for (let i = 0; i < AUDIT_INVALID_METADATA_LIMIT + 10; i += 1) {
+    flood.push({ path: `handbook/flood-${i}.md`, content: "---\nschema_version: 9\nid: x\n---\n" });
+  }
+  const audit = auditRecords(flood);
+  assert.equal(audit.metadataValid, false);
+  assert.equal(audit.invalidMetadataCount, AUDIT_INVALID_METADATA_LIMIT + 10);
+  assert.equal(audit.invalidMetadata.length, AUDIT_INVALID_METADATA_LIMIT);
 }
 
 console.log("dsh-memory metadata tests passed");

--- a/tests/test_dsh_memory_sync_dry_run.sh
+++ b/tests/test_dsh_memory_sync_dry_run.sh
@@ -1,16 +1,23 @@
 #!/usr/bin/env zsh
 set -euo pipefail
 
+# v0.8.3: --scan-only (and its deprecated --dry-run alias) is the zero-Provider
+# acceptance path. It reports the candidate scan without starting DSH, without
+# acquiring the operation lock, without writing a journal or pending state,
+# and without advancing the .last-sync watermark.
+
 PROJECT_DIR="$(cd -- "$(dirname -- "$0")/.." && pwd -P)"
 SYNC_SOURCE="$PROJECT_DIR/integrations/dsh/dsh-memory-sync"
 INITIALIZER="$PROJECT_DIR/integrations/dsh/dsh-memory-init"
-TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/dsh-memory-sync-dry-run.XXXXXX")"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/dsh-memory-sync-scan-only.XXXXXX")"
 TEST_INTEGRATION="$TEST_ROOT/integrations/dsh"
 TEST_HOME="$TEST_ROOT/home"
 TEST_DSH_HOME="$TEST_ROOT/dsh-home"
 TEST_MEMORY_ROOT="$TEST_ROOT/memory"
 TEST_BIN="$TEST_ROOT/bin"
-OUTPUT="$TEST_ROOT/dry-run-output.txt"
+CANARY_HIT="$TEST_ROOT/canary-hit"
+OUT="$TEST_ROOT/scan-out.txt"
+ERR="$TEST_ROOT/scan-err.txt"
 
 mkdir -p "$TEST_INTEGRATION" "$TEST_HOME" "$TEST_DSH_HOME/sessions" "$TEST_MEMORY_ROOT" "$TEST_BIN"
 cp "$SYNC_SOURCE" "$TEST_INTEGRATION/dsh-memory-sync"
@@ -23,43 +30,126 @@ mkdir -p "${DSH_MEMORY_ROOT:?}"
 EOF
 chmod +x "$TEST_INTEGRATION/dsh-memory-init"
 
-DSH_HOME="$TEST_DSH_HOME" DSH_MEMORY_ROOT="$TEST_MEMORY_ROOT" "$INITIALIZER" >/dev/null
-rm -f "$TEST_MEMORY_ROOT/.last-sync"
+# Real initializer (via env) prepares the git-backed memory root; the stub
+# above is what dsh-memory-sync itself invokes in scan-only mode (and it must
+# never be reached, because scan-only skips the initializer).
+DSH_HOME="$TEST_DSH_HOME" DSH_MEMORY_ROOT="$TEST_MEMORY_ROOT" \
+  GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@example.com \
+  GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@example.com \
+  "$INITIALIZER" >/dev/null
 
-cat > "$TEST_BIN/dsh" <<'EOF'
+# A canary DSH stub: if any sync path reaches DSH, the test fails loudly.
+cat > "$TEST_BIN/dsh" <<EOF
 #!/bin/zsh
-set -euo pipefail
-printf 'synthetic memory entry\n' > handbook/synthetic.md
-exit 0
+print -r -- hit > "$CANARY_HIT"
+exit 42
 EOF
 chmod +x "$TEST_BIN/dsh"
 
-# dry-run must report the would-be changes without applying them.
+run_sync() {
+  env \
+    HOME="$TEST_HOME" \
+    DSH_HOME="$TEST_DSH_HOME" \
+    DSH_MEMORY_ROOT="$TEST_MEMORY_ROOT" \
+    DSH_BIN="$TEST_BIN/dsh" \
+    DPSK_MEMORY_SYNC_HELPER="$TEST_INTEGRATION/sync-apply.py" \
+    GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@example.com \
+    GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@example.com \
+    PATH="$TEST_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    zsh "$TEST_INTEGRATION/dsh-memory-sync" "$@"
+}
+
+assert_no_side_effects() {
+  test ! -e "$CANARY_HIT"
+  test ! -e "$TEST_MEMORY_ROOT/.sync/operation.lock"
+  test ! -e "$TEST_MEMORY_ROOT/.sync/active-run.json"
+  test ! -d "$TEST_MEMORY_ROOT/.sync/runs"
+  test ! -e "$TEST_MEMORY_ROOT/.sync/last-run.json"
+  test ! -e "$TEST_MEMORY_ROOT/.sync/pending-candidates.json"
+  local dirty
+  dirty="$(git -C "$TEST_MEMORY_ROOT" status --porcelain | grep -v '^ D \.last-sync$' || true)"
+  [[ -z "$dirty" ]] || { print -u2 -- "unexpected live-root changes: $dirty"; exit 1; }
+}
+
+# --- Case 1: first run (no watermark) — JSON reports an absent watermark and
+# zero candidates, with zero side effects.
+rm -f "$TEST_MEMORY_ROOT/.last-sync"
 set +e
-env \
-  HOME="$TEST_HOME" \
-  DSH_HOME="$TEST_DSH_HOME" \
-  DSH_MEMORY_ROOT="$TEST_MEMORY_ROOT" \
-  DSH_BIN="$TEST_BIN/dsh" \
-  DPSK_MEMORY_SYNC_HELPER="$TEST_INTEGRATION/sync-apply.py" \
-  PATH="$TEST_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-  zsh "$TEST_INTEGRATION/dsh-memory-sync" --dry-run > "$OUTPUT" 2>&1
+run_sync --scan-only --json > "$OUT" 2> "$ERR"
 rc=$?
 set -e
 test "$rc" = "0"
-grep -q -- 'dry-run' "$OUTPUT"
-grep -q -- 'handbook/synthetic.md' "$OUTPUT"
-
-# dry-run must not modify the live root, journal, or watermark. The .sync
-# directory itself is created by the initializer (with its .gitignore), but a
-# dry-run must not create a lock, an active-run record, or any run journal.
-test ! -e "$TEST_MEMORY_ROOT/handbook/synthetic.md"
-test ! -e "$TEST_MEMORY_ROOT/.sync/operation.lock"
-test ! -e "$TEST_MEMORY_ROOT/.sync/active-run.json"
-test ! -d "$TEST_MEMORY_ROOT/.sync/runs"
-test ! -e "$TEST_MEMORY_ROOT/.sync/last-run.json"
+/usr/bin/python3 - "$OUT" <<'PY'
+import json, sys
+data = json.loads(open(sys.argv[1]).read())
+assert data["ok"] is True and data["scanOnly"] is True, data
+assert data["watermark"] == "absent", data
+assert data["candidateSessions"] == 0, data
+assert data["candidates"] == [], data
+PY
+assert_no_side_effects
 test ! -e "$TEST_MEMORY_ROOT/.last-sync"
-# The marker was removed by the test itself; nothing else in the live root may change.
-test "$(git -C "$TEST_MEMORY_ROOT" status --porcelain | grep -v '^ D .last-sync$' | wc -l | tr -d ' ')" = "0"
 
-print -- "dsh-memory sync dry-run tests passed"
+# --- Case 2: watermark present plus one idle (2h-old) session newer than the
+# marker — JSON reports the candidate with bytes and digest, the watermark
+# state stays "set", and the marker mtime is untouched.
+git -C "$TEST_MEMORY_ROOT" checkout -- .last-sync
+touch -t "$(date -v-3H +%Y%m%d%H%M)" "$TEST_MEMORY_ROOT/.last-sync"
+SESSION_DIR="$TEST_DSH_HOME/sessions/sess-scan-0001"
+mkdir -p "$SESSION_DIR"
+printf 'synthetic session payload\n' > "$SESSION_DIR/session.jsonl.zstd"
+touch -t "$(date -v-2H +%Y%m%d%H%M)" "$SESSION_DIR/session.jsonl.zstd"
+marker_mtime_before="$(stat -f %m "$TEST_MEMORY_ROOT/.last-sync")"
+set +e
+run_sync --scan-only --json > "$OUT" 2> "$ERR"
+rc=$?
+set -e
+test "$rc" = "0"
+/usr/bin/python3 - "$OUT" "$SESSION_DIR/session.jsonl.zstd" <<'PY'
+import json, sys
+data = json.loads(open(sys.argv[1]).read())
+expected = sys.argv[2]
+assert data["ok"] is True and data["scanOnly"] is True, data
+assert data["watermark"] == "set", data
+assert data["candidateSessions"] == 1, data
+assert data["candidates"][0]["path"] == expected, data
+assert data["candidates"][0]["bytes"] > 0, data
+digest = data["candidates"][0]["digest"]
+assert len(digest) == 64 and all(c in "0123456789abcdef" for c in digest), data
+PY
+marker_mtime_after="$(stat -f %m "$TEST_MEMORY_ROOT/.last-sync")"
+test "$marker_mtime_before" = "$marker_mtime_after"
+assert_no_side_effects
+test -e "$TEST_MEMORY_ROOT/.last-sync"
+
+# Text mode reports the same scan in prose.
+set +e
+run_sync --scan-only > "$OUT" 2> "$ERR"
+rc=$?
+set -e
+test "$rc" = "0"
+grep -q -- 'scan-only: 1 candidate session(s)' "$OUT" "$ERR" || {
+  print -u2 -- "text scan-only output missing candidate summary"; exit 1; }
+assert_no_side_effects
+
+# --- Case 3: --dry-run is a deprecated alias of --scan-only: it warns on
+# stderr, never runs the model, and has zero side effects.
+set +e
+run_sync --dry-run > "$OUT" 2> "$ERR"
+rc=$?
+set -e
+test "$rc" = "0"
+grep -q -- '--dry-run is deprecated' "$ERR"
+assert_no_side_effects
+
+# --- Case 4: --scan-only and --preview are mutually exclusive (fail-closed).
+set +e
+run_sync --scan-only --preview some-id > "$OUT" 2> "$ERR"
+rc=$?
+set -e
+test "$rc" != "0"
+grep -q -- 'mutually exclusive' "$ERR"
+assert_no_side_effects
+
+rm -rf "$TEST_ROOT"
+print -- "dsh-memory sync scan-only tests passed"

--- a/tests/test_dsh_memory_sync_preview.sh
+++ b/tests/test_dsh_memory_sync_preview.sh
@@ -1,7 +1,8 @@
 #!/bin/zsh
 # v0.3.1: the sync wrapper can capture a candidate diff as a pending preview
-# (--preview), apply a preview (--apply-preview), discard it
-# (--discard-preview), and emit a machine-parseable dry-run report (--json).
+# (--preview), apply a preview (--apply-preview), and discard it
+# (--discard-preview). v0.8.3: --dry-run is a deprecated alias of --scan-only
+# and no longer emits a diff report.
 set -euo pipefail
 
 PROJECT_DIR="$(cd -- "$(dirname -- "$0")/.." && pwd -P)"
@@ -104,35 +105,30 @@ set -e
 test "$mutex_rc" != "0"
 grep -q -- "mutually exclusive" "$TEST_ROOT/mutex.out"
 
-# 5. --dry-run --json emits a single machine-parseable JSON document. After the
-#    apply above there are no new changes, so the report has empty lists but
-#    must still be valid JSON with the schema shape.
-run_sync --dry-run --json >"$TEST_ROOT/dry.json" 2>/dev/null
+# 5. --dry-run is a deprecated alias of --scan-only: it warns on stderr and
+#    emits the scan-only JSON contract (no diff report, no model run). The
+#    session above is still an unconsumed candidate because preview apply
+#    never advances the watermark.
+marker_before="$(stat -f %m "$TEST_MEMORY_ROOT/.last-sync")"
+run_sync --dry-run --json >"$TEST_ROOT/dry.json" 2>"$TEST_ROOT/dry.err"
+grep -q -- '--dry-run is deprecated' "$TEST_ROOT/dry.err"
 /usr/bin/python3 - "$TEST_ROOT/dry.json" <<'PY'
 import json
 import sys
 report = json.load(open(sys.argv[1]))
 assert report["ok"] is True, report
-assert report["dryRun"] is True, report
-assert isinstance(report["changedPaths"], list), report
-assert isinstance(report["added"], list), report
-assert isinstance(report["modified"], list), report
-assert isinstance(report["deleted"], list), report
-assert "candidateSessions" in report, report
+assert report["scanOnly"] is True, report
+assert report["watermark"] == "set", report
+assert report["candidateSessions"] == 1, report
+assert isinstance(report["candidates"], list) and len(report["candidates"]) == 1, report
 PY
 
-# 6. A fresh dry-run --json over a new session change reports the paths.
-rm -f "$TEST_MEMORY_ROOT/.last-sync"
-touch -t 200001010000 "$TEST_MEMORY_ROOT/.last-sync"
-: > "$TEST_DSH_HOME/sessions/session.jsonl.zstd"
-touch -t 200001010001 "$TEST_DSH_HOME/sessions/session.jsonl.zstd"
-run_sync --dry-run --json >"$TEST_ROOT/dry2.json" 2>/dev/null
-/usr/bin/python3 - "$TEST_ROOT/dry2.json" <<'PY'
-import json
-import sys
-report = json.load(open(sys.argv[1]))
-assert "handbook/preview-cli.md" in report["changedPaths"], report
-assert report["candidateSessions"] == 1, report
-PY
+# 6. The alias run stays side-effect free: no lock, journal, pending state,
+#    and the watermark is untouched.
+test ! -e "$TEST_MEMORY_ROOT/.sync/operation.lock"
+test ! -e "$TEST_MEMORY_ROOT/.sync/active-run.json"
+test ! -d "$TEST_MEMORY_ROOT/.sync/runs"
+test ! -e "$TEST_MEMORY_ROOT/.sync/pending-candidates.json"
+test "$(stat -f %m "$TEST_MEMORY_ROOT/.last-sync")" = "$marker_before"
 
 print -- "dsh-memory sync preview tests passed"

--- a/tools/public-tree-check.mjs
+++ b/tools/public-tree-check.mjs
@@ -242,9 +242,9 @@ try {
     }
 
     const expectedManifestVersions = {
-      "package.json": "0.8.2",
-      "packages/dsh-memory/package.json": "0.8.2",
-      "packages/dsh-memory-ui/package.json": "0.8.1",
+      "package.json": "0.8.3",
+      "packages/dsh-memory/package.json": "0.8.3",
+      "packages/dsh-memory-ui/package.json": "0.8.3",
     };
     for (const manifestPath of Object.keys(expectedManifestVersions)) {
       const content = readSnapshotText(snapshot, manifestPath);


### PR DESCRIPTION
## Summary
- Metadata audit (metadataValid / valid- & invalidMetadataCount / ≤20 invalidMetadata entries); invalid metadata surfaces as a dedicated UI warning and is excluded from search/context with per-file warnings
- Flow-style front matter rejected with stable `flow-style-metadata` code
- Single-writer contract: normal sessions treat the memory repo as read-only; memory skill bumped to 1.2.0 (extract/consolidate/forget become memory requests)
- README / .sync/.gitignore / filter_session.py are managed readonly templates with single "Refresh managed memory templates" commit and dirty fail-closed behavior
- `--scan-only [--json]` zero-Provider acceptance path; `--dry-run` is a deprecated alias
- Prompt freshness: memory section re-renders on summary.md changes (5s poll + debounce)

## Test plan
- All 28 test suites green (run individually: shell + node)
- Metadata audit, flow-style rejection, init refresh, scan-only contract tests updated/added