### PR TITLE
feat: v0.9.0 hybrid retrieval with derived SQLite search index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [0.8.3] - 2026-09-01
+
+### Added
+
+- Metadata audit: `status`/`health` now report `metadataValid`,
+  `validMetadataCount`, `invalidMetadataCount`, and up to 20 `invalidMetadata`
+  entries. Metadata anomalies surface as a dedicated UI warning ("记忆数据格式
+  异常") and never fold into `needsManualRecovery`.
+- Search and context exclude records with invalid metadata from retrieval and
+  return per-file `warnings` with stable error codes instead of failing.
+- Flow-style front matter collections (`tags: [a, b]`) are rejected with the
+  stable `flow-style-metadata` code; new/updated records must use canonical
+  block lists.
+- Single-writer coordination: the memory section now instructs normal sessions
+  to treat the memory repository as read-only and record memory requests in
+  their session output; the periodic transactional sync performs extraction,
+  consolidation, and git commits. README templates document the write boundary
+  and the canonical front matter format.
+- README.md, `.sync/.gitignore`, and `scripts/filter_session.py` are managed
+  readonly templates: identical checksum is a no-op, a dirty live copy fails
+  closed, changed files are replaced atomically and committed once as
+  "Refresh managed memory templates".
+- `--scan-only [--json]` is the zero-Provider acceptance path: it reports
+  candidates, raw bytes, digests, pending state, and the watermark without
+  starting DSH, acquiring the operation lock, writing a journal, or advancing
+  the watermark. `--dry-run` is a deprecated alias that no longer runs the
+  model.
+- Prompt freshness: the memory section re-renders when `summary.md` changes
+  (polled every 5s, debounced, watcher stopped on cleanup, brief file absence
+  keeps the previous snapshot).
+
+### Changed
+
+- The memory skill (v1.2.0) turns extract/consolidate/forget into memory
+  requests recorded in session output; direct file writes and git commits are
+  removed from normal sessions. Forget defaults to archive/correction with
+  explicit `supersedes`.
+
 ## [0.8.2] - 2026-08-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-09-01
+
+### Added
+
+- Hybrid retrieval pipeline: `memory.search()` and `memory.context()` now fuse
+  a full-corpus lexical scan with a derived SQLite full-text index. Raw
+  lexical rank, FTS rank, coverage rank, and usage rank are combined with
+  reciprocal-rank fusion (k=60, weights raw 2.0 / FTS 1.0 / coverage 1.0 /
+  usage 0.25), and exact-substring matches keep a dedicated precedence tier
+  above all fused scoring.
+- Derived search index at `.sync/search-index.sqlite` (permission `0600`):
+  a `content_fts` table with the trigram tokenizer (CJK runs of 3+ characters
+  and latin words of 3+ characters) plus a `terms_fts` table with `unicode61`
+  terms over English words and CJK bigrams. The index is stamped with
+  `sha256(payloadTree(HEAD))`, built into a temporary database that is atomically
+  renamed into place, and kept out of the working tree via `.git/info/exclude`.
+- Retrieval API metadata: responses gain `retrieval`
+  (`mode`: `hybrid` or `scan`; `indexState`: `fresh`, `rebuilt`, or
+  `degraded`; `stamp`), and results gain `score` plus `score_components`
+  (`raw`, `fts`, `coverage`, `usage` contributions) in both search and
+  query-aware context responses.
+- Transparent degradation: when the index is missing, stale, or corrupt it is
+  rebuilt automatically; if rebuilding fails (for example an unwritable
+  `.sync` directory) retrieval falls back to the pure scan with
+  `indexState: "degraded"` and identical results.
+- Retrieval evaluation suite (`tests/test_dsh_memory_retrieval_eval.mjs`):
+  52 labeled queries over a 26-record mixed Chinese/English corpus asserting
+  top-1/top-3 recall, scope filtering, exact-tier precedence over usage
+  reinforcement, usage-unchanged invariants, index permissions, working-tree
+  cleanliness,   stamp invalidation on new commits, and corrupt-index
+  degradation.
+
 ## [0.8.4] - 2026-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-09-01
+
+### Added
+
+- Raw caps and model input caps are now separate budgets: raw session files
+  (`DSH_MEMORY_MAX_SESSION_FILE_BYTES`, 64 MiB default), decompressed
+  payloads (`DSH_MEMORY_MAX_SESSION_DECOMPRESSED_BYTES`, 128 MiB default),
+  and per-chunk bytes (`DSH_MEMORY_MAX_CHUNK_BYTES`, 1 MiB default) bound the
+  host side, while `DSH_MEMORY_MAX_CANDIDATE_BYTES` (8 MiB default) bounds
+  the model input per run.
+- Streaming sanitizer: `filter_session.py` decodes zstd/plain session logs
+  line by line without materializing the payload, fails closed with
+  `decompressed-too-large`, and writes fixed-size sanitized chunks prefixed
+  with a provenance header (`session_id`, `session_digest`,
+  `chunk_index/chunk_total`).
+- Per-candidate delivery with resume: size-class rejections are counted per
+  candidate (`rejected_candidate_count`) instead of aborting the batch;
+  partially delivered sessions are deferred (`deferred_candidate_count`) and
+  recorded in pending-candidates v2 (`digest`, `next_chunk`, `chunk_total`,
+  `complete`), so the next run resumes from the first undelivered chunk
+  without re-paying the provider for delivered chunks.
+- Journal records and scan-only output gain `processed_chunk_count`,
+  `deferred_candidate_count`, and `rejected_candidate_count`.
+
+### Changed
+
+- Size-class rejections (`raw cap`, `decompressed-too-large`) no longer fail
+  the batch: the watermark is held past unresolved candidates and the run is
+  journaled zero-cost (`rejected`/`deferred`) when nothing reaches the model.
+  Infrastructure failures (missing decoder, crashed filter, unreadable chunk
+  metadata) keep failing the whole batch closed.
+- The watermark only advances past a fully resolved window: truncation,
+  deferrals, and rejections all hold it in place.
+- The consolidation prompt documents the chunked contract (group by
+  `session_id`, read chunks in `chunk_index` order, undelivered chunks
+  arrive on the next run).
+
 ## [0.8.3] - 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ not expose the filesystem root or execute Git directly.
 
 ## Compatibility
 
-`v0.8.2` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
+`v0.8.3` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
 tested and locally integrated with a consistently pinned `0.1.0-rc.7` graph:
 
 | Component | Supported version |
@@ -103,7 +103,7 @@ Clone the repository and install its reproducible development/runtime dependenci
 ```zsh
 git clone https://github.com/seriousz158/dsh-memory.git
 cd dsh-memory
-# Use the pinned runtime that this v0.8.2 integration was tested with.
+# Use the pinned runtime that this v0.8.3 integration was tested with.
 npm install --global @deepseek-ai/dsh@0.1.0-rc.7
 dsh --version
 npm ci --ignore-scripts

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ not expose the filesystem root or execute Git directly.
 
 ## Compatibility
 
-`v0.8.3` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
+`v0.8.4` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
 tested and locally integrated with a consistently pinned `0.1.0-rc.7` graph:
 
 | Component | Supported version |
@@ -103,7 +103,7 @@ Clone the repository and install its reproducible development/runtime dependenci
 ```zsh
 git clone https://github.com/seriousz158/dsh-memory.git
 cd dsh-memory
-# Use the pinned runtime that this v0.8.3 integration was tested with.
+# Use the pinned runtime that this v0.8.4 integration was tested with.
 npm install --global @deepseek-ai/dsh@0.1.0-rc.7
 dsh --version
 npm ci --ignore-scripts

--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ for historical changes.
 - When enabled, a bounded and explicitly untrusted `summary.md` snapshot is
   available to the model (12 KiB maximum).
 - `memory.search()` and `memory.context()` provide local, bounded retrieval
-  with source citations and usage-aware deterministic ordering.
+  with source citations and usage-aware deterministic ordering. Retrieval is
+  hybrid: a derived SQLite index (FTS5 trigram + CJK-bigram/word terms, stored
+  at `.sync/search-index.sqlite` with restrictive permissions) is fused with
+  lexical scoring and exact-substring precedence, and transparently falls back
+  to a pure scan when the index is missing, stale, or corrupt.
 - Read usage is stored as private metadata in `.sync/usage.json`; transcripts,
   prompts, credentials, and memory content are not written to journals.
 
@@ -58,7 +62,7 @@ not expose the filesystem root or execute Git directly.
 
 ## Compatibility
 
-`v0.8.4` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
+`v0.9.0` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
 tested and locally integrated with a consistently pinned `0.1.0-rc.7` graph:
 
 | Component | Supported version |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -101,7 +101,7 @@ The sync command does not install DSH. It requires a `dsh` executable on `PATH`,
 The wrapper also discovers a local Homebrew or nvm Node runtime when launchd
 starts with a minimal `PATH`; no interactive shell profile is required.
 
-The v0.8.2 host and UI packages still declare the runtime peer range
+The v0.8.3 host and UI packages still declare the runtime peer range
 `@deepseek-ai/dsh@^0.1.0-rc.6`, so DSH `rc.6` remains peer-compatible. The
 repository's reproducible clean-room and local integration baseline is
 `0.1.0-rc.7`, because the registry's `rc.6` transitive peer graph is not

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -101,7 +101,7 @@ The sync command does not install DSH. It requires a `dsh` executable on `PATH`,
 The wrapper also discovers a local Homebrew or nvm Node runtime when launchd
 starts with a minimal `PATH`; no interactive shell profile is required.
 
-The v0.8.3 host and UI packages still declare the runtime peer range
+The v0.8.4 host and UI packages still declare the runtime peer range
 `@deepseek-ai/dsh@^0.1.0-rc.6`, so DSH `rc.6` remains peer-compatible. The
 repository's reproducible clean-room and local integration baseline is
 `0.1.0-rc.7`, because the registry's `rc.6` transitive peer graph is not

--- a/integrations/dsh/dsh-memory-init
+++ b/integrations/dsh/dsh-memory-init
@@ -72,25 +72,41 @@ harden_initialized_repository() {
   chmod 700 "$MEMORY_ROOT/scripts/filter_session.py"
 }
 
-refresh_helper_script() {
-  local helper_path="$MEMORY_ROOT/scripts/filter_session.py"
-  local helper_status
+refresh_managed_templates() {
+  # Managed readonly files: the host owns them; the model never edits them.
+  # For each template: identical checksum is a no-op; a dirty (uncommitted)
+  # live copy fails closed; otherwise the file is replaced atomically and a
+  # single commit records only the changed managed files.
+  typeset -a managed_relpaths
+  managed_relpaths=(README.md .sync/.gitignore scripts/filter_session.py)
+  typeset -a changed
+  changed=()
+  local relpath
+  local live_path
+  local template_path
+  local entry_status
   local temporary_path
-
-  helper_status="$($git_bin -C "$MEMORY_ROOT" status --porcelain --untracked-files=all -- scripts/filter_session.py)"
-  [[ -z "$helper_status" ]] || die "refusing to refresh a dirty memory helper"
-  cmp -s "$TEMPLATE_ROOT/scripts/filter_session.py" "$helper_path" && return 0
-
-  temporary_path="$(/usr/bin/mktemp "$MEMORY_ROOT/scripts/.filter_session.py.XXXXXX")"
-  if ! "$install_bin" -m 700 "$TEMPLATE_ROOT/scripts/filter_session.py" "$temporary_path"; then
-    rm -f -- "$temporary_path"
-    die "could not stage the refreshed memory helper"
-  fi
-  mv -f -- "$temporary_path" "$helper_path"
-  chmod 700 "$helper_path"
-  "$git_bin" -C "$MEMORY_ROOT" add -- scripts/filter_session.py
-  "$git_bin" -C "$MEMORY_ROOT" commit --quiet --only -m "Refresh helper scripts" -- scripts/filter_session.py \
-    || die "could not commit the refreshed memory helper"
+  for relpath in "${managed_relpaths[@]}"; do
+    live_path="$MEMORY_ROOT/$relpath"
+    template_path="$TEMPLATE_ROOT/$relpath"
+    entry_status="$($git_bin -C "$MEMORY_ROOT" status --porcelain --untracked-files=all -- "$relpath")"
+    [[ -z "$entry_status" ]] || die "refusing to refresh a dirty managed template: $relpath"
+    cmp -s "$template_path" "$live_path" && continue
+    temporary_path="$(/usr/bin/mktemp "$MEMORY_ROOT/.$(basename -- "$relpath").refresh.XXXXXX")"
+    if ! "$install_bin" -m 600 "$template_path" "$temporary_path"; then
+      rm -f -- "$temporary_path"
+      die "could not stage the refreshed managed template: $relpath"
+    fi
+    mv -f -- "$temporary_path" "$live_path"
+    chmod 600 "$live_path"
+    changed+=("$relpath")
+  done
+  (( ${#changed} == 0 )) && return 0
+  local helper_path="$MEMORY_ROOT/scripts/filter_session.py"
+  [[ -f "$helper_path" ]] && chmod 700 "$helper_path"
+  "$git_bin" -C "$MEMORY_ROOT" add -- "${changed[@]}"
+  "$git_bin" -C "$MEMORY_ROOT" commit --quiet --only -m "Refresh managed memory templates" -- "${changed[@]}" \
+    || die "could not commit the refreshed managed templates"
 }
 
 if [[ -e "$MEMORY_ROOT" || -L "$MEMORY_ROOT" ]]; then
@@ -111,7 +127,7 @@ if [[ -e "$MEMORY_ROOT" || -L "$MEMORY_ROOT" ]]; then
       die "memory .sync/.gitignore is unsafe"
     fi
     validate_initialized_repository || die "memory root is an incomplete DSH memory repository"
-    refresh_helper_script
+    refresh_managed_templates
     harden_initialized_repository || die "could not restore private memory repository permissions"
     print -- "$root_real"
     exit 0

--- a/integrations/dsh/dsh-memory-sync
+++ b/integrations/dsh/dsh-memory-sync
@@ -6,11 +6,13 @@
 # Git commits (recovery + apply), records a run journal, and only then advances
 # the .last-sync watermark. A host-side operation lock serializes sync runs and
 # an active-run record lets an interrupted run be recovered on the next sync.
-# A --dry-run flag reports the candidate diff without touching the live root,
-# the journal, the lock, or Git.
+# v0.8.3: --scan-only --json reports candidates, raw bytes, pending state, and
+# the watermark with zero side effects (no DSH, no provider, no lock, no
+# journal, no watermark move). --dry-run is a deprecated alias of --scan-only
+# and never runs the model; a model-generated diff requires --preview <id>.
 # Zero-change runs journal a no_change record and advance the watermark so
-# the same candidate window is never rescanned; dry-run and preview runs
-# remain side-effect free (no journal record, no watermark move).
+# the same candidate window is never rescanned; preview runs remain
+# side-effect free (no journal record, no watermark move).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd -P)"
@@ -22,7 +24,7 @@ MARKER="$DSH_MEMORY_ROOT/.last-sync"
 PENDING_CANDIDATES="$DSH_MEMORY_ROOT/.sync/pending-candidates.json"
 DSH_BIN="${DSH_BIN:-dsh}"
 DSH_PERMISSION_MODE="${DSH_PERMISSION_MODE:-workspace-write}"
-SYNC_POLICY_VERSION="${DSH_MEMORY_SYNC_POLICY_VERSION:-v0.8.2}"
+SYNC_POLICY_VERSION="${DSH_MEMORY_SYNC_POLICY_VERSION:-v0.8.3}"
 MAX_CANDIDATE_SESSIONS="${DSH_MEMORY_MAX_CANDIDATE_SESSIONS:-10}"
 MAX_CANDIDATE_BYTES="${DSH_MEMORY_MAX_CANDIDATE_BYTES:-8388608}"
 RETRY_COOLDOWN_SECONDS="${DSH_MEMORY_RETRY_COOLDOWN_SECONDS:-3600}"
@@ -38,7 +40,7 @@ CANDIDATE_MANIFEST_TMP=""
 CANDIDATE_TRUNCATED=0
 CANDIDATE_LIMIT_ERROR=""
 
-DRY_RUN=0
+SCAN_ONLY=0
 PREVIEW_MODE=0
 APPLY_PREVIEW=""
 DISCARD_PREVIEW=""
@@ -47,7 +49,15 @@ RETRY_FAILED=0
 PREVIEW_ID=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --dry-run) DRY_RUN=1; shift ;;
+    # --dry-run is a deprecated alias of --scan-only: it reports the candidate
+    # scan and never starts DSH or a provider. A model-generated diff requires
+    # an explicit --preview <id>.
+    --dry-run)
+      SCAN_ONLY=1
+      print -u2 -- "dsh-memory-sync: --dry-run is deprecated and no longer runs the model; use --scan-only to scan, or --preview <id> for a model-generated diff."
+      shift
+      ;;
+    --scan-only) SCAN_ONLY=1; shift ;;
     --preview)
       PREVIEW_MODE=1
       PREVIEW_ID="${2:-}"
@@ -70,8 +80,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 # The preview management modes are mutually exclusive with a normal sync.
-if [[ "$DRY_RUN" == "1" && "$PREVIEW_MODE" == "1" ]]; then
-  print -u2 -- "dsh-memory-sync: --dry-run and --preview are mutually exclusive"
+if [[ "$SCAN_ONLY" == "1" && "$PREVIEW_MODE" == "1" ]]; then
+  print -u2 -- "dsh-memory-sync: --scan-only and --preview are mutually exclusive"
   exit 2
 fi
 management_modes=0
@@ -236,7 +246,7 @@ PY
 
 write_pending_candidates() {
   if [[ "$CANDIDATE_TRUNCATED" != "1" ]]; then
-    [[ "$DRY_RUN" == "0" && "$PREVIEW_MODE" == "0" ]] && rm -f -- "$PENDING_CANDIDATES"
+    [[ "$PREVIEW_MODE" == "0" ]] && rm -f -- "$PENDING_CANDIDATES"
     return 0
   fi
   "$PYTHON_BIN" - "$PENDING_CANDIDATES" "${CANDIDATE_FILES[@]}" <<'PY'
@@ -305,6 +315,10 @@ if [[ ! -x "$INITIALIZER" ]]; then
   exit 127
 fi
 
+# Scan-only mode is a read-only inspection: it must not run the initializer
+# (which can commit refreshed managed templates), acquire a lock, write a
+# journal, or advance the watermark.
+
 # Build a small, credential-free base environment before invoking any child.
 # The initializer only needs local filesystem and Git access; provider values
 # are intentionally unavailable until the final DSH process is started.
@@ -325,7 +339,46 @@ for env_name in ${(k)parameters}; do
   fi
 done
 
-/usr/bin/env -i "${BASE_ENV[@]}" "$INITIALIZER" >/dev/null
+if [[ "$SCAN_ONLY" != "1" ]]; then
+  /usr/bin/env -i "${BASE_ENV[@]}" "$INITIALIZER" >/dev/null
+fi
+
+# --- Scan-only mode (--scan-only [--json]) ---
+# Reports candidates, raw bytes, pending state, and the watermark without
+# starting DSH or a provider, without acquiring the operation lock, without
+# writing a journal, and without advancing the watermark. This is the
+# zero-Provider acceptance path; a model-generated diff requires an explicit
+# --preview <id>.
+emit_scan_only() {
+  local candidates_json="["
+  local candidate
+  local size
+  local digest
+  local first=1
+  for candidate in "${CANDIDATE_FILES[@]}"; do
+    size="$(stat -f %z -- "$candidate" 2>/dev/null || print 0)"
+    digest="$(candidate_file_digest "$candidate")"
+    (( first == 1 )) || candidates_json+=","
+    first=0
+    candidates_json+="{\"path\":\"$candidate\",\"bytes\":$size,\"digest\":\"$digest\"}"
+  done
+  candidates_json+="]"
+  local pending_count=0
+  [[ -f "$PENDING_CANDIDATES" ]] && pending_count="$(pending_candidate_lines | wc -l | tr -d ' ')"
+  local watermark_state="absent"
+  [[ -f "$MARKER" ]] && watermark_state="set"
+  printf '{"ok":true,"scanOnly":true,"memoryRoot":"%s","watermark":"%s","candidateSessions":%s,"candidateBytes":%s,"truncated":%s,"limitError":%s,"pendingEntries":%s,"candidates":%s}\n' \
+    "$DSH_MEMORY_ROOT" \
+    "$watermark_state" \
+    "$CANDIDATE_SESSIONS" \
+    "$CANDIDATE_BYTES" \
+    "$([[ "$CANDIDATE_TRUNCATED" == "1" ]] && print true || print false)" \
+    "$([[ -n "$CANDIDATE_LIMIT_ERROR" ]] && printf '"%s"' "$CANDIDATE_LIMIT_ERROR" || print null)" \
+    "$pending_count" \
+    "$candidates_json"
+}
+
+
 
 # --- Preview management modes (--apply-preview / --discard-preview) ---
 # These are short host-side operations handled before any session scan: they
@@ -416,22 +469,30 @@ if [[ -f "$MARKER" ]]; then
   CANDIDATE_DIGEST="$(candidate_digest "${CANDIDATE_FILES[@]}")"
   if [[ -n "$CANDIDATE_LIMIT_ERROR" ]]; then
     progress "candidate batch rejected: $CANDIDATE_LIMIT_ERROR"
-  elif [[ "$CANDIDATE_SESSIONS" == "0" ]]; then
-    [[ "$DRY_RUN" == "0" && "$PREVIEW_MODE" == "0" ]] && rm -f -- "$PENDING_CANDIDATES"
-    if [[ "$DRY_RUN" == "1" ]]; then
-      if [[ "$JSON_OUTPUT" == "1" ]]; then
-        printf '{"ok":true,"dryRun":true,"candidateSessions":0,"changedPaths":[],"message":"no new idle session logs"}\n'
-      else
-        echo "dsh-memory-sync: dry-run: no new idle session logs since $(stat -f '%Sm' "$MARKER"), nothing to do."
-      fi
-    else
-      echo "dsh-memory-sync: no new idle session logs since $(stat -f '%Sm' "$MARKER"), nothing to do."
-    fi
+  elif [[ "$CANDIDATE_SESSIONS" == "0" && "$SCAN_ONLY" != "1" ]]; then
+    # Scan-only stays side-effect free: zero candidates are reported through
+    # the scan-only output paths below instead of this early exit, and a
+    # read-only inspection must never clear pending state as a side effect.
+    [[ "$PREVIEW_MODE" == "0" ]] && rm -f -- "$PENDING_CANDIDATES"
+    echo "dsh-memory-sync: no new idle session logs since $(stat -f '%Sm' "$MARKER"), nothing to do."
     exit 0
   fi
   progress "$CANDIDATE_SESSIONS new idle session log(s), starting headless consolidation…"
 else
   progress "first run — marker will be created, historical sessions skipped."
+fi
+
+if [[ "$SCAN_ONLY" == "1" ]]; then
+  if [[ "$JSON_OUTPUT" == "1" ]]; then
+    emit_scan_only
+  elif [[ -n "$CANDIDATE_LIMIT_ERROR" ]]; then
+    print -u2 -- "dsh-memory-sync: scan-only: candidate batch rejected: $CANDIDATE_LIMIT_ERROR"
+  elif [[ "$CANDIDATE_SESSIONS" == "0" ]]; then
+    echo "dsh-memory-sync: scan-only: no new idle session logs, nothing to do."
+  else
+    echo "dsh-memory-sync: scan-only: $CANDIDATE_SESSIONS candidate session(s), $CANDIDATE_BYTES bytes$( [[ "$CANDIDATE_TRUNCATED" == "1" ]] && print ', truncated' )."
+  fi
+  exit 0
 fi
 
 DSH_EXECUTABLE="$(command -v -- "$DSH_BIN" 2>/dev/null || true)"
@@ -462,54 +523,44 @@ cleanup_sync_operation() {
 }
 trap cleanup_sync_operation EXIT
 
-if [[ "$DRY_RUN" == "0" ]]; then
-  lock_output=""
-  if ! lock_output="$(sync_apply acquire-lock --root "$DSH_MEMORY_ROOT" --operation-name sync --run-id "$RUN_ID")"; then
-    sync_apply lock-rejection --root "$DSH_MEMORY_ROOT" --operation-name sync --run-id "$RUN_ID" \
-      --error-code operation-in-progress >/dev/null 2>&1 || true
-    print -u2 -- "dsh-memory-sync: another sync operation is in progress"
-    exit 1
-  fi
-  LOCK_HELD=1
-  if [[ "$RETRY_FAILED" == "0" && -n "$CANDIDATE_DIGEST" ]]; then
-    retry_output="$(sync_apply retry-check --root "$DSH_MEMORY_ROOT" --candidate-digest "$CANDIDATE_DIGEST" \
-      --sync-policy-version "$SYNC_POLICY_VERSION" --cooldown-seconds "$RETRY_COOLDOWN_SECONDS")"
-    if [[ "$(printf '%s' "$retry_output" | "$PYTHON_BIN" -c 'import json,sys; print(str(json.load(sys.stdin).get("value", {}).get("suppressed", False)).lower())')" == "true" ]]; then
-      retry_error="$(printf '%s' "$retry_output" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin).get("value", {}).get("error_code") or "sync-failed")')"
-      sync_apply journal --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
-        --status skipped-retry --started-at "$STARTED_AT" --candidate-sessions "$CANDIDATE_SESSIONS" \
-        --processed-sessions 0 --skipped-sessions "$CANDIDATE_SESSIONS" --changed-paths "" \
-        --error-code "$retry_error" --phase retry --candidate-digest "$CANDIDATE_DIGEST" \
-        --sync-policy-version "$SYNC_POLICY_VERSION" --suppress-last-run >/dev/null 2>&1 || true
-      print -u2 -- "dsh-memory-sync: retry suppressed for $CANDIDATE_DIGEST"
-      exit 0
-    fi
-  fi
-  # A previous sync may have been interrupted (dead pid + active-run record).
-  # Recover it into the journal before starting a fresh run.
-  recover_output="$(sync_apply recover-active --root "$DSH_MEMORY_ROOT")" || {
-    print -u2 -- "dsh-memory-sync: active run recovery failed: $recover_output"
-    exit 1
-  }
-  recovered="$(printf '%s' "$recover_output" | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["value"]["recovered"])')"
-  if [[ "$recovered" == "True" ]]; then
-    progress "recovered an interrupted run; see the run journal."
-  fi
-  sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
-    --phase staging --started-at "$STARTED_AT" >/dev/null
+lock_output=""
+if ! lock_output="$(sync_apply acquire-lock --root "$DSH_MEMORY_ROOT" --operation-name sync --run-id "$RUN_ID")"; then
+  sync_apply lock-rejection --root "$DSH_MEMORY_ROOT" --operation-name sync --run-id "$RUN_ID" \
+    --error-code operation-in-progress >/dev/null 2>&1 || true
+  print -u2 -- "dsh-memory-sync: another sync operation is in progress"
+  exit 1
 fi
+LOCK_HELD=1
+if [[ "$RETRY_FAILED" == "0" && -n "$CANDIDATE_DIGEST" ]]; then
+  retry_output="$(sync_apply retry-check --root "$DSH_MEMORY_ROOT" --candidate-digest "$CANDIDATE_DIGEST" \
+    --sync-policy-version "$SYNC_POLICY_VERSION" --cooldown-seconds "$RETRY_COOLDOWN_SECONDS")"
+  if [[ "$(printf '%s' "$retry_output" | "$PYTHON_BIN" -c 'import json,sys; print(str(json.load(sys.stdin).get("value", {}).get("suppressed", False)).lower())')" == "true" ]]; then
+    retry_error="$(printf '%s' "$retry_output" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin).get("value", {}).get("error_code") or "sync-failed")')"
+    sync_apply journal --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
+      --status skipped-retry --started-at "$STARTED_AT" --candidate-sessions "$CANDIDATE_SESSIONS" \
+      --processed-sessions 0 --skipped-sessions "$CANDIDATE_SESSIONS" --changed-paths "" \
+      --error-code "$retry_error" --phase retry --candidate-digest "$CANDIDATE_DIGEST" \
+      --sync-policy-version "$SYNC_POLICY_VERSION" --suppress-last-run >/dev/null 2>&1 || true
+    print -u2 -- "dsh-memory-sync: retry suppressed for $CANDIDATE_DIGEST"
+    exit 0
+  fi
+fi
+# A previous sync may have been interrupted (dead pid + active-run record).
+# Recover it into the journal before starting a fresh run.
+recover_output="$(sync_apply recover-active --root "$DSH_MEMORY_ROOT")" || {
+  print -u2 -- "dsh-memory-sync: active run recovery failed: $recover_output"
+  exit 1
+}
+recovered="$(printf '%s' "$recover_output" | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["value"]["recovered"])')"
+if [[ "$recovered" == "True" ]]; then
+  progress "recovered an interrupted run; see the run journal."
+fi
+sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
+  --phase staging --started-at "$STARTED_AT" >/dev/null
 
 if [[ -n "$CANDIDATE_LIMIT_ERROR" ]]; then
-  if [[ "$DRY_RUN" == "1" ]]; then
-    if [[ "$JSON_OUTPUT" == "1" ]]; then
-      printf '{"ok":false,"dryRun":true,"error":{"code":"%s"}}\n' "$CANDIDATE_LIMIT_ERROR"
-    else
-      print -u2 -- "dsh-memory-sync: candidate batch rejected: $CANDIDATE_LIMIT_ERROR"
-    fi
-  else
-    write_failure_record "$CANDIDATE_LIMIT_ERROR" candidate-scan
-    print -u2 -- "dsh-memory-sync: candidate batch rejected: $CANDIDATE_LIMIT_ERROR"
-  fi
+  write_failure_record "$CANDIDATE_LIMIT_ERROR" candidate-scan
+  print -u2 -- "dsh-memory-sync: candidate batch rejected: $CANDIDATE_LIMIT_ERROR"
   exit 1
 fi
 
@@ -641,10 +692,8 @@ fi
 PROCESSED_SESSIONS="$CANDIDATE_SESSIONS"
 
 # --- Host-side verification and apply ---
-if [[ "$DRY_RUN" == "0" ]]; then
-  sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
-    --phase validating --started-at "$STARTED_AT" >/dev/null
-fi
+sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
+  --phase validating --started-at "$STARTED_AT" >/dev/null
 difference=""
 if ! difference="$(sync_apply diff --staging "$STAGING" --manifest "$MANIFEST" --run-id "$RUN_ID")"; then
   diff_error="$(json_error_code "$difference")"
@@ -662,21 +711,14 @@ diff_bytes="$(printf '%s' "$difference" | /usr/bin/python3 -c 'import json,sys; 
 json_list() { [[ -z "$1" ]] && printf '[]' || printf '[%s]' "$(printf '%s' "$1" | /usr/bin/sed 's/\([^,]*\)/"\1"/g')"; }
 
 if [[ -z "$changed_paths" ]]; then
-  if [[ "$DRY_RUN" == "1" && "$JSON_OUTPUT" == "1" ]]; then
-    printf '{"ok":true,"dryRun":true,"candidateSessions":%s,"changedPaths":[],"message":"no changes"}\n' "$CANDIDATE_SESSIONS"
-  else
-    echo "dsh-memory-sync: no memory changes, nothing to apply."
-    if [[ "$DRY_RUN" == "1" ]]; then
-      echo "dsh-memory-sync: dry-run: no changes would be applied."
-    fi
-  fi
+  echo "dsh-memory-sync: no memory changes, nothing to apply."
   # Zero-change runs still advance the watermark and journal a no_change
   # record: every candidate was delivered to the model, so rescanning the
   # same window forever would only repeat paid model calls. The run did not
   # touch the live payload, so finalize commits only .sync + .last-sync.
   # Preview runs are excluded: preview mode is an operator-review tool and
   # stays non-journaling (see the preview contract comment near the end).
-  if [[ "$DRY_RUN" == "0" && "$PREVIEW_MODE" == "0" ]]; then
+  if [[ "$PREVIEW_MODE" == "0" ]]; then
     typeset -a FINALIZE_LAST_SYNC_ARGS
     FINALIZE_LAST_SYNC_ARGS=()
     [[ "$CANDIDATE_TRUNCATED" == "1" ]] || FINALIZE_LAST_SYNC_ARGS=(--last-sync "$START_TS")
@@ -709,17 +751,6 @@ if [[ -z "$changed_paths" ]]; then
   exit 0
 fi
 
-if [[ "$DRY_RUN" == "1" ]]; then
-  if [[ "$JSON_OUTPUT" == "1" ]]; then
-    printf '{"ok":true,"dryRun":true,"candidateSessions":%s,"changedPaths":%s,"added":%s,"modified":%s,"deleted":%s,"changedBytes":%s}\n' \
-      "$CANDIDATE_SESSIONS" "$(json_list "$changed_paths")" "$(json_list "$diff_added")" "$(json_list "$diff_modified")" "$(json_list "$diff_deleted")" "$diff_bytes"
-  else
-    echo "dsh-memory-sync: dry-run — would apply: $changed_paths"
-  fi
-  rm -rf -- "$STAGING_PARENT"
-  exit 0
-fi
-
 # --- Preview mode: stage the candidate diff under .sync/previews/<id> and
 # leave it pending. Nothing is applied, journaled, or committed here; the
 # model edit is captured so an operator can review and apply it later.
@@ -747,10 +778,8 @@ if [[ "$PREVIEW_MODE" == "1" ]]; then
   exit 0
 fi
 
-if [[ "$DRY_RUN" == "0" ]]; then
-  sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
-    --phase applying --started-at "$STARTED_AT" >/dev/null
-fi
+sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
+  --phase applying --started-at "$STARTED_AT" >/dev/null
 apply_result="$(sync_apply apply --root "$DSH_MEMORY_ROOT" --staging "$STAGING" --manifest "$MANIFEST" --run-id "$RUN_ID" --started-at "$STARTED_AT")" || {
   apply_error="$(json_error_code "$apply_result")"
   # Record the failure in the journal so the run is auditable even when the
@@ -766,10 +795,8 @@ apply_commit="$(printf '%s' "$apply_result" | /usr/bin/python3 -c 'import json,s
 
 # Journal the run and advance the watermark only after a successful apply.
 DURATION_MS=$(( ( $(date +%s) - START_TS ) * 1000 ))
-if [[ "$DRY_RUN" == "0" ]]; then
-  sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
-    --phase finalizing --started-at "$STARTED_AT" >/dev/null
-fi
+sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
+  --phase finalizing --started-at "$STARTED_AT" >/dev/null
 finalize_output=""
 typeset -a FINALIZE_LAST_SYNC_ARGS
 FINALIZE_LAST_SYNC_ARGS=()
@@ -799,11 +826,9 @@ fi
 write_pending_candidates
 sync_apply clear-failure-sentinel --root "$DSH_MEMORY_ROOT" >/dev/null 2>&1 || true
 
-if [[ "$DRY_RUN" == "0" ]]; then
-  sync_apply clear-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" >/dev/null 2>&1 || true
-  sync_apply release-lock --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" >/dev/null 2>&1 || true
-  LOCK_HELD=0
-fi
+sync_apply clear-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" >/dev/null 2>&1 || true
+sync_apply release-lock --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" >/dev/null 2>&1 || true
+LOCK_HELD=0
 
 echo "dsh-memory-sync: applied $changed_paths (recovery $recovery_commit, apply $apply_commit, run $RUN_ID)."
 rm -rf -- "$STAGING_PARENT"

--- a/integrations/dsh/dsh-memory-sync
+++ b/integrations/dsh/dsh-memory-sync
@@ -13,6 +13,13 @@
 # Zero-change runs journal a no_change record and advance the watermark so
 # the same candidate window is never rescanned; preview runs remain
 # side-effect free (no journal record, no watermark move).
+# v0.8.4: raw candidate caps (64 MiB per session file, 128 MiB decompressed,
+# 1 MiB sanitized chunks) are separated from the model input batch caps.
+# Sessions are redacted by a streaming decoder, split into headered chunks
+# (session_id/session_digest/chunk_index/chunk_total), and oversized or
+# partially delivered sessions are rejected/deferred per candidate instead of
+# aborting the batch; the watermark never advances past unresolved or
+# rejected candidates and the journal carries chunk/defer/reject counts.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd -P)"
@@ -24,13 +31,22 @@ MARKER="$DSH_MEMORY_ROOT/.last-sync"
 PENDING_CANDIDATES="$DSH_MEMORY_ROOT/.sync/pending-candidates.json"
 DSH_BIN="${DSH_BIN:-dsh}"
 DSH_PERMISSION_MODE="${DSH_PERMISSION_MODE:-workspace-write}"
-SYNC_POLICY_VERSION="${DSH_MEMORY_SYNC_POLICY_VERSION:-v0.8.3}"
+SYNC_POLICY_VERSION="${DSH_MEMORY_SYNC_POLICY_VERSION:-v0.8.4}"
+# Model input batch caps: how much sanitized transcript is delivered per run.
 MAX_CANDIDATE_SESSIONS="${DSH_MEMORY_MAX_CANDIDATE_SESSIONS:-10}"
 MAX_CANDIDATE_BYTES="${DSH_MEMORY_MAX_CANDIDATE_BYTES:-8388608}"
+# Raw candidate caps (v0.8.4): these bound the host-side filter pipeline, not
+# the model input. A session file over the raw cap is rejected per candidate
+# (never batch-fatal); the decoder enforces the decompressed cap while
+# streaming; sanitized transcripts are split into headered chunks.
+MAX_SESSION_FILE_BYTES="${DSH_MEMORY_MAX_SESSION_FILE_BYTES:-67108864}"
+MAX_SESSION_DECOMPRESSED_BYTES="${DSH_MEMORY_MAX_SESSION_DECOMPRESSED_BYTES:-134217728}"
+MAX_CHUNK_BYTES="${DSH_MEMORY_MAX_CHUNK_BYTES:-1048576}"
 RETRY_COOLDOWN_SECONDS="${DSH_MEMORY_RETRY_COOLDOWN_SECONDS:-3600}"
 # These are host-lifecycle metrics, never numbers inferred from the model's
 # natural-language report. Candidates pass the watermark and one-hour idle
-# guards; a successful headless invocation processes every candidate it receives.
+# guards; a successful headless invocation processes every candidate chunk it
+# receives.
 CANDIDATE_SESSIONS=0
 PROCESSED_SESSIONS=0
 SKIPPED_SESSIONS=0
@@ -39,6 +55,11 @@ CANDIDATE_DIGEST=""
 CANDIDATE_MANIFEST_TMP=""
 CANDIDATE_TRUNCATED=0
 CANDIDATE_LIMIT_ERROR=""
+REJECTED_CANDIDATE_COUNT=0
+DEFERRED_CANDIDATE_COUNT=0
+PROCESSED_CHUNK_COUNT=0
+typeset -a PENDING_RECORDS
+PENDING_RECORDS=()
 
 SCAN_ONLY=0
 PREVIEW_MODE=0
@@ -221,13 +242,29 @@ try:
     value = json.loads(pathlib.Path(sys.argv[1]).read_text())
 except (OSError, UnicodeDecodeError, json.JSONDecodeError):
     raise SystemExit(0)
-for path, digest in (value.get("entries") or {}).items():
-    if isinstance(path, str) and isinstance(digest, str):
-        print(f"{path}\t{digest}")
+entries = value.get("entries") if isinstance(value, dict) else None
+if not isinstance(entries, dict):
+    raise SystemExit(0)
+for path, state in entries.items():
+    # Schema 1 stores a plain digest string; schema 2 (v0.8.4) stores
+    # {digest, next_chunk, chunk_total, complete}.
+    if isinstance(state, dict):
+        digest = str(state.get("digest", ""))
+        next_chunk = int(state.get("next_chunk", 1) or 1)
+        complete = bool(state.get("complete", False))
+    elif isinstance(state, str):
+        digest = state
+        next_chunk = 1
+        complete = False
+    else:
+        continue
+    print(f"{path}\t{digest}\t{next_chunk}\t{1 if complete else 0}")
 PY
 }
 
-pending_candidate_digest() {
+# Print "<next_chunk>\t<complete>" for a pending entry whose digest matches,
+# or nothing when the path is unknown or its digest changed.
+pending_entry_state() {
   local candidate="$1"
   local digest="$2"
   [[ -f "$PENDING_CANDIDATES" ]] || return 1
@@ -240,22 +277,47 @@ try:
     value = json.loads(pathlib.Path(sys.argv[1]).read_text())
 except (OSError, UnicodeDecodeError, json.JSONDecodeError):
     raise SystemExit(1)
-raise SystemExit(0 if (value.get("entries") or {}).get(sys.argv[2]) == sys.argv[3] else 1)
+entries = value.get("entries") if isinstance(value, dict) else None
+if not isinstance(entries, dict):
+    raise SystemExit(1)
+state = entries.get(sys.argv[2])
+if isinstance(state, dict):
+    digest = str(state.get("digest", ""))
+    next_chunk = int(state.get("next_chunk", 1) or 1)
+    complete = bool(state.get("complete", False))
+elif isinstance(state, str):
+    digest = state
+    next_chunk = 1
+    complete = False
+else:
+    raise SystemExit(1)
+if digest != sys.argv[3]:
+    raise SystemExit(1)
+print(f"{next_chunk}\t{1 if complete else 0}")
 PY
 }
 
+# Pending state (schema 2, v0.8.4). PENDING_RECORDS carries one
+# "path<TAB>digest<TAB>next_chunk<TAB>chunk_total<TAB>complete" quintuple per
+# candidate touched this run: deferred (partially delivered) sessions keep
+# complete=false with the resume chunk; fully delivered sessions are recorded
+# with complete=true only when the batch was truncated, so the next run can
+# skip them without paying the provider twice. Entries for untouched paths
+# survive until their session file disappears or their entry completes.
 write_pending_candidates() {
-  if [[ "$CANDIDATE_TRUNCATED" != "1" ]]; then
-    [[ "$PREVIEW_MODE" == "0" ]] && rm -f -- "$PENDING_CANDIDATES"
+  if [[ "$PREVIEW_MODE" == "1" ]]; then
     return 0
   fi
-  "$PYTHON_BIN" - "$PENDING_CANDIDATES" "${CANDIDATE_FILES[@]}" <<'PY'
+  if (( ${#PENDING_RECORDS} == 0 )); then
+    rm -f -- "$PENDING_CANDIDATES"
+    return 0
+  fi
+  "$PYTHON_BIN" - "$PENDING_CANDIDATES" "${PENDING_RECORDS[@]}" <<'PY'
 import json
 import os
 import pathlib
 import sys
 import tempfile
-import hashlib
 
 state_path = pathlib.Path(sys.argv[1])
 try:
@@ -265,18 +327,35 @@ except (OSError, UnicodeDecodeError, json.JSONDecodeError):
 entries = current.get("entries") if isinstance(current, dict) else {}
 if not isinstance(entries, dict):
     entries = {}
-for path in sys.argv[2:]:
+batch_paths = set()
+for record in sys.argv[2:]:
+    path, digest, next_chunk, chunk_total, complete = record.split("\t")
+    batch_paths.add(path)
+    entries[path] = {
+        "digest": digest,
+        "next_chunk": int(next_chunk),
+        "chunk_total": int(chunk_total),
+        "complete": complete == "1",
+    }
+# Entries this run did not touch stay only while they still describe real
+# deferred work; completed entries for vanished sessions are dropped.
+for path in [key for key in list(entries) if key not in batch_paths]:
+    state = entries[path]
+    if not (isinstance(state, dict) and state.get("complete") is True):
+        del entries[path]
+live = {path: state for path, state in entries.items() if state}
+if not live:
     try:
-        digest = hashlib.sha256(pathlib.Path(path).read_bytes()).hexdigest()
-    except OSError:
-        continue
-    entries[path] = digest
+        state_path.unlink()
+    except FileNotFoundError:
+        pass
+    raise SystemExit(0)
 state_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
 fd, temporary = tempfile.mkstemp(prefix=".pending-candidates.", dir=state_path.parent)
 try:
     os.fchmod(fd, 0o600)
     with os.fdopen(fd, "w", encoding="utf-8") as handle:
-        json.dump({"schema_version": 1, "entries": entries}, handle, separators=(",", ":"))
+        json.dump({"schema_version": 2, "entries": live}, handle, separators=(",", ":"))
         handle.write("\n")
     os.replace(temporary, state_path)
 finally:
@@ -367,13 +446,13 @@ emit_scan_only() {
   [[ -f "$PENDING_CANDIDATES" ]] && pending_count="$(pending_candidate_lines | wc -l | tr -d ' ')"
   local watermark_state="absent"
   [[ -f "$MARKER" ]] && watermark_state="set"
-  printf '{"ok":true,"scanOnly":true,"memoryRoot":"%s","watermark":"%s","candidateSessions":%s,"candidateBytes":%s,"truncated":%s,"limitError":%s,"pendingEntries":%s,"candidates":%s}\n' \
+  printf '{"ok":true,"scanOnly":true,"memoryRoot":"%s","watermark":"%s","candidateSessions":%s,"candidateBytes":%s,"truncated":%s,"rejectedCandidates":%s,"pendingEntries":%s,"candidates":%s}\n' \
     "$DSH_MEMORY_ROOT" \
     "$watermark_state" \
     "$CANDIDATE_SESSIONS" \
     "$CANDIDATE_BYTES" \
     "$([[ "$CANDIDATE_TRUNCATED" == "1" ]] && print true || print false)" \
-    "$([[ -n "$CANDIDATE_LIMIT_ERROR" ]] && printf '"%s"' "$CANDIDATE_LIMIT_ERROR" || print null)" \
+    "$REJECTED_CANDIDATE_COUNT" \
     "$pending_count" \
     "$candidates_json"
 }
@@ -423,11 +502,13 @@ if [[ -f "$MARKER" ]]; then
     [[ -n "$candidate" ]] && CANDIDATE_FILES+=("$candidate")
   done < <(find "$DSH_HOME/sessions" -name 'session.jsonl.zstd' -newer "$MARKER" ! -newermt '-1 hour' -print 2>/dev/null | sort)
   # A capped batch intentionally leaves the watermark unchanged. Re-add the
-  # pending paths on the next run, then filter hashes already delivered so a
-  # new session cannot cause the previous batch to be sent to the provider a
-  # second time.
-  while IFS=$'\t' read -r pending_path pending_digest; do
+  # pending paths on the next run, then drop entries that are already fully
+  # delivered so a new session cannot cause the previous batch to be sent to
+  # the provider a second time. Deferred (partially delivered) entries stay
+  # in the list and resume from their recorded next chunk.
+  while IFS=$'\t' read -r pending_path pending_digest pending_chunk pending_complete; do
     [[ -n "$pending_path" && -f "$pending_path" ]] || continue
+    [[ "$pending_complete" == "1" ]] && continue
     [[ "$(find "$pending_path" -newermt '-1 hour' -print -quit 2>/dev/null)" == "" ]] || continue
     already_listed=0
     for candidate in "${CANDIDATE_FILES[@]}"; do
@@ -439,7 +520,10 @@ if [[ -f "$MARKER" ]]; then
   UNPROCESSED_CANDIDATES=()
   for candidate in "${CANDIDATE_FILES[@]}"; do
     candidate_hash="$(candidate_file_digest "$candidate")"
-    if pending_candidate_digest "$candidate" "$candidate_hash"; then
+    if pending_entry_state "$candidate" "$candidate_hash" | {
+      read -r entry_chunk entry_complete
+      [[ "$entry_complete" == "1" ]]
+    }; then
       continue
     fi
     UNPROCESSED_CANDIDATES+=("$candidate")
@@ -449,15 +533,14 @@ if [[ -f "$MARKER" ]]; then
   LIMITED_CANDIDATES=()
   for candidate in "${CANDIDATE_FILES[@]}"; do
     local_size="$(stat -f %z -- "$candidate" 2>/dev/null || print 0)"
-    if (( local_size > MAX_CANDIDATE_BYTES )); then
-      CANDIDATE_LIMIT_ERROR="candidate-too-large"
-      break
+    if (( local_size > MAX_SESSION_FILE_BYTES )); then
+      # v0.8.4: oversized raw sessions are rejected per candidate instead of
+      # aborting the batch; the watermark below never advances past them.
+      REJECTED_CANDIDATE_COUNT=$((REJECTED_CANDIDATE_COUNT + 1))
+      progress "candidate rejected: session file exceeds the ${MAX_SESSION_FILE_BYTES}-byte raw cap"
+      continue
     fi
     if (( ${#LIMITED_CANDIDATES} >= MAX_CANDIDATE_SESSIONS )); then
-      CANDIDATE_TRUNCATED=1
-      break
-    fi
-    if (( CANDIDATE_BYTES + local_size > MAX_CANDIDATE_BYTES )); then
       CANDIDATE_TRUNCATED=1
       break
     fi
@@ -467,17 +550,24 @@ if [[ -f "$MARKER" ]]; then
   CANDIDATE_FILES=("${LIMITED_CANDIDATES[@]}")
   CANDIDATE_SESSIONS=${#CANDIDATE_FILES}
   CANDIDATE_DIGEST="$(candidate_digest "${CANDIDATE_FILES[@]}")"
-  if [[ -n "$CANDIDATE_LIMIT_ERROR" ]]; then
-    progress "candidate batch rejected: $CANDIDATE_LIMIT_ERROR"
-  elif [[ "$CANDIDATE_SESSIONS" == "0" && "$SCAN_ONLY" != "1" ]]; then
-    # Scan-only stays side-effect free: zero candidates are reported through
-    # the scan-only output paths below instead of this early exit, and a
-    # read-only inspection must never clear pending state as a side effect.
-    [[ "$PREVIEW_MODE" == "0" ]] && rm -f -- "$PENDING_CANDIDATES"
-    echo "dsh-memory-sync: no new idle session logs since $(stat -f '%Sm' "$MARKER"), nothing to do."
-    exit 0
+  if [[ "$CANDIDATE_SESSIONS" == "0" ]]; then
+    if [[ "$SCAN_ONLY" != "1" ]]; then
+      # Scan-only stays side-effect free: zero candidates are reported through
+      # the scan-only output paths below instead of this early exit, and a
+      # read-only inspection must never clear pending state as a side effect.
+      if (( REJECTED_CANDIDATE_COUNT == 0 )); then
+        [[ "$PREVIEW_MODE" == "0" ]] && rm -f -- "$PENDING_CANDIDATES"
+        echo "dsh-memory-sync: no new idle session logs since $(stat -f '%Sm' "$MARKER"), nothing to do."
+      else
+        # Rejected candidates hold the watermark and their pending state so
+        # the next run can retry them once the operator intervenes.
+        echo "dsh-memory-sync: 0 deliverable session(s), $REJECTED_CANDIDATE_COUNT rejected by the raw cap; watermark held."
+      fi
+      exit 0
+    fi
+  else
+    progress "$CANDIDATE_SESSIONS new idle session log(s), starting headless consolidation…"
   fi
-  progress "$CANDIDATE_SESSIONS new idle session log(s), starting headless consolidation…"
 else
   progress "first run — marker will be created, historical sessions skipped."
 fi
@@ -485,12 +575,10 @@ fi
 if [[ "$SCAN_ONLY" == "1" ]]; then
   if [[ "$JSON_OUTPUT" == "1" ]]; then
     emit_scan_only
-  elif [[ -n "$CANDIDATE_LIMIT_ERROR" ]]; then
-    print -u2 -- "dsh-memory-sync: scan-only: candidate batch rejected: $CANDIDATE_LIMIT_ERROR"
   elif [[ "$CANDIDATE_SESSIONS" == "0" ]]; then
     echo "dsh-memory-sync: scan-only: no new idle session logs, nothing to do."
   else
-    echo "dsh-memory-sync: scan-only: $CANDIDATE_SESSIONS candidate session(s), $CANDIDATE_BYTES bytes$( [[ "$CANDIDATE_TRUNCATED" == "1" ]] && print ', truncated' )."
+    echo "dsh-memory-sync: scan-only: $CANDIDATE_SESSIONS candidate session(s), $CANDIDATE_BYTES bytes$( [[ "$CANDIDATE_TRUNCATED" == "1" ]] && print ', truncated' )$( (( REJECTED_CANDIDATE_COUNT > 0 )) && print ", $REJECTED_CANDIDATE_COUNT rejected" )."
   fi
   exit 0
 fi
@@ -558,12 +646,6 @@ fi
 sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
   --phase staging --started-at "$STARTED_AT" >/dev/null
 
-if [[ -n "$CANDIDATE_LIMIT_ERROR" ]]; then
-  write_failure_record "$CANDIDATE_LIMIT_ERROR" candidate-scan
-  print -u2 -- "dsh-memory-sync: candidate batch rejected: $CANDIDATE_LIMIT_ERROR"
-  exit 1
-fi
-
 # --- Transaction setup: an isolated staging worktree + baseline manifest ---
 STAGING_PARENT="${TMPDIR:-/tmp}/dsh-memory-sync-$$"
 STAGING="$STAGING_PARENT/staging"
@@ -597,26 +679,120 @@ fi
 mkdir -m 700 -p "$SANITIZED_INPUT_ROOT"
 : > "$CANDIDATE_MANIFEST_TMP"
 FILTER_ERROR_TMP="$STAGING_PARENT/filter-error.txt"
+CHUNK_META_TMP="$STAGING_PARENT/chunk-meta.json"
+# v0.8.4 per-candidate delivery: each session is redacted by the streaming
+# decoder and split into headered chunks. Raw caps are enforced per candidate
+# (rejection is journal-counted, never batch-fatal); the model input batch cap
+# applies to delivered chunk bytes and defers the remainder to the next run.
+DELIVERED_CHUNK_BYTES=0
+typeset -a DELIVERED_CHUNK_FILES
+DELIVERED_CHUNK_FILES=()
 if [[ "${#CANDIDATE_FILES}" -gt 0 ]]; then
   input_index=0
   for candidate in "${CANDIDATE_FILES[@]}"; do
-    input_name="$(printf 'session-%04d.md' "$input_index")"
-    input_path="$SANITIZED_INPUT_ROOT/$input_name"
+    candidate_hash="$(candidate_file_digest "$candidate")"
+    next_chunk=1
+    entry_state="$(pending_entry_state "$candidate" "$candidate_hash" 2>/dev/null || true)"
+    if [[ -n "$entry_state" ]]; then
+      entry_chunk="${entry_state%%$'\t'*}"
+      entry_complete="${entry_state##*$'\t'}"
+      if [[ "$entry_complete" != "1" && "$entry_chunk" =~ '^[0-9]+$' ]]; then
+        next_chunk="$entry_chunk"
+      fi
+    fi
+    session_base="$(printf 'session-%04d' "$input_index")"
+    chunk_dir="$SANITIZED_INPUT_ROOT/$session_base"
+    mkdir -m 700 -p -- "$chunk_dir"
     : > "$FILTER_ERROR_TMP"
-    if ! "$PYTHON_BIN" "$FILTER_SESSION" "$candidate" > "$input_path" 2>"$FILTER_ERROR_TMP"; then
+    if ! "$PYTHON_BIN" "$FILTER_SESSION" "$candidate" \
+        --chunk-dir "$chunk_dir" --chunk-bytes "$MAX_CHUNK_BYTES" \
+        --session-digest "$candidate_hash" \
+        --max-decompressed-bytes "$MAX_SESSION_DECOMPRESSED_BYTES" \
+        > "$CHUNK_META_TMP" 2>"$FILTER_ERROR_TMP"; then
       filter_error_code="input-filter-failed"
       if grep -q -- '^zstd-unavailable:' "$FILTER_ERROR_TMP"; then
         filter_error_code="zstd-unavailable"
+      elif grep -q -- '^decompressed-too-large:' "$FILTER_ERROR_TMP"; then
+        filter_error_code="decompressed-too-large"
       fi
+      if [[ "$filter_error_code" == "decompressed-too-large" ]]; then
+        # Oversized decompressed payload: reject this candidate only; the
+        # watermark below never advances past it, so it stays unresolved.
+        REJECTED_CANDIDATE_COUNT=$((REJECTED_CANDIDATE_COUNT + 1))
+        progress "candidate rejected: decompressed-too-large"
+        rm -rf -- "$chunk_dir"
+        input_index=$((input_index + 1))
+        continue
+      fi
+      # Infrastructure failures (missing decoder, crashed filter) fail the
+      # whole run closed: silently skipping every session would hide a
+      # broken pipeline behind an empty journal.
       write_failure_record "$filter_error_code" staging
       print -u2 -- "dsh-memory-sync: failed to filter a candidate session: $filter_error_code"
       rm -rf -- "$STAGING_PARENT"
       exit 1
     fi
-    chmod 600 "$input_path"
-    print -r -- "$input_path" >> "$CANDIDATE_MANIFEST_TMP"
+    chunk_total="$("$PYTHON_BIN" -c 'import json,sys; print(json.load(open(sys.argv[1]))["chunk_total"])' "$CHUNK_META_TMP" 2>/dev/null || true)"
+    if [[ ! "$chunk_total" =~ '^[0-9]+$' ]]; then
+      write_failure_record "input-filter-failed" staging
+      print -u2 -- "dsh-memory-sync: failed to filter a candidate session: unreadable chunk metadata"
+      rm -rf -- "$STAGING_PARENT"
+      exit 1
+    fi
+    delivered_chunks=0
+    resume_chunk=""
+    for (( chunk_no = next_chunk; chunk_no <= chunk_total; chunk_no++ )); do
+      chunk_path="$chunk_dir/$session_base.chunk$(printf '%02d' "$chunk_no").md"
+      chunk_size="$(stat -f %z -- "$chunk_path" 2>/dev/null || print -1)"
+      if (( chunk_size < 0 )); then
+        write_failure_record "input-filter-failed" staging
+        print -u2 -- "dsh-memory-sync: failed to filter a candidate session: missing chunk $chunk_no"
+        rm -rf -- "$STAGING_PARENT"
+        exit 1
+      fi
+      if (( DELIVERED_CHUNK_BYTES + chunk_size > MAX_CANDIDATE_BYTES )); then
+        resume_chunk="$chunk_no"
+        break
+      fi
+      DELIVERED_CHUNK_FILES+=("$chunk_path")
+      DELIVERED_CHUNK_BYTES=$((DELIVERED_CHUNK_BYTES + chunk_size))
+      delivered_chunks=$((delivered_chunks + 1))
+    done
+    PROCESSED_CHUNK_COUNT=$((PROCESSED_CHUNK_COUNT + delivered_chunks))
+    if [[ -n "$resume_chunk" ]]; then
+      DEFERRED_CANDIDATE_COUNT=$((DEFERRED_CANDIDATE_COUNT + 1))
+      PENDING_RECORDS+=("$(printf '%s\t%s\t%s\t%s\t0' "$candidate" "$candidate_hash" "$resume_chunk" "$chunk_total")")
+    elif (( next_chunk <= chunk_total && delivered_chunks == chunk_total - next_chunk + 1 && CANDIDATE_TRUNCATED == 1 )); then
+      # Fully delivered inside a truncated batch: mark complete so the next
+      # run skips this session without paying for it a second time.
+      PENDING_RECORDS+=("$(printf '%s\t%s\t%s\t%s\t1' "$candidate" "$candidate_hash" "$((chunk_total + 1))" "$chunk_total")")
+    fi
     input_index=$((input_index + 1))
   done
+fi
+for chunk_path in "${DELIVERED_CHUNK_FILES[@]}"; do
+  print -r -- "$chunk_path" >> "$CANDIDATE_MANIFEST_TMP"
+done
+if (( ${#DELIVERED_CHUNK_FILES} == 0 )); then
+  # Nothing reached the model: every candidate was rejected, deferred, or
+  # already fully delivered. Journal the run without a paid model call and
+  # hold the watermark so unresolved candidates stay in the scan window.
+  DURATION_MS=$(( ( $(date +%s) - START_TS ) * 1000 ))
+  deferred_status="deferred"
+  if (( REJECTED_CANDIDATE_COUNT > 0 && DEFERRED_CANDIDATE_COUNT == 0 )); then
+    deferred_status="rejected"
+  fi
+  sync_apply journal --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation-name sync \
+    --status "$deferred_status" --started-at "$STARTED_AT" --candidate-sessions "$CANDIDATE_SESSIONS" \
+    --processed-sessions 0 --skipped-sessions "$CANDIDATE_SESSIONS" --changed-paths "" \
+    --phase complete --duration-ms "$DURATION_MS" --candidate-digest "$CANDIDATE_DIGEST" \
+    --sync-policy-version "$SYNC_POLICY_VERSION" \
+    --processed-chunk-count 0 --deferred-candidate-count "$DEFERRED_CANDIDATE_COUNT" \
+    --rejected-candidate-count "$REJECTED_CANDIDATE_COUNT" >/dev/null 2>&1 || true
+  write_pending_candidates
+  echo "dsh-memory-sync: 0 chunk(s) delivered ($DEFERRED_CANDIDATE_COUNT deferred, $REJECTED_CANDIDATE_COUNT rejected); watermark held."
+  rm -rf -- "$STAGING_PARENT"
+  exit 0
 fi
 
 # The rc.7 headless bundle deliberately persists every one-shot session. If
@@ -640,7 +816,7 @@ STAGING_PROMPT="你是 dsh-memory 的定时记忆整合代理，现在执行一�
 
 宿主已在本地完成候选筛选和凭据脱敏。你只能读取临时脱敏转录，不能访问原始会话日志、真实 DSH_HOME 或真实记忆库。
 
-候选会话清单：$CANDIDATE_MANIFEST_TMP（每行是 staging 内的临时脱敏转录；宿主已按每轮最多 $MAX_CANDIDATE_SESSIONS 个会话、总输入最多 $MAX_CANDIDATE_BYTES 字节截断；只处理清单中的路径）。
+候选会话清单：$CANDIDATE_MANIFEST_TMP（每行是 staging 内的一个脱敏转录分块文件。每个分块头部用 HTML 注释标注 session_id、session_digest 与 chunk_index/chunk_total：同一会话可能被拆成多个分块，请按其 session_id 分组、按 chunk_index 顺序合并阅读后再提炼；只处理清单中的路径。宿主已按每轮最多 $MAX_CANDIDATE_SESSIONS 个会话、模型输入最多 $MAX_CANDIDATE_BYTES 字节截断，未交付的分块会在下一轮继续送入）。
 
 步骤：
 1. 逐行读取候选会话清单中的临时脱敏转录，按 README「提炼与整合」一节的提炼要求提炼（无高信号则输出 NO_SIGNAL 并跳过该会话）。
@@ -721,7 +897,12 @@ if [[ -z "$changed_paths" ]]; then
   if [[ "$PREVIEW_MODE" == "0" ]]; then
     typeset -a FINALIZE_LAST_SYNC_ARGS
     FINALIZE_LAST_SYNC_ARGS=()
-    [[ "$CANDIDATE_TRUNCATED" == "1" ]] || FINALIZE_LAST_SYNC_ARGS=(--last-sync "$START_TS")
+    # The watermark only advances past a window that was fully resolved:
+    # truncation, deferrals, and rejections all hold it in place so the
+    # unresolved candidates are rescanned on the next run.
+    if [[ "$CANDIDATE_TRUNCATED" == "0" && "$DEFERRED_CANDIDATE_COUNT" == "0" && "$REJECTED_CANDIDATE_COUNT" == "0" ]]; then
+      FINALIZE_LAST_SYNC_ARGS=(--last-sync "$START_TS")
+    fi
     DURATION_MS=$(( ( $(date +%s) - START_TS ) * 1000 ))
     finalize_output=""
     if ! finalize_output="$(sync_apply finalize \
@@ -738,6 +919,9 @@ if [[ -z "$changed_paths" ]]; then
       --duration-ms "$DURATION_MS" \
       --candidate-digest "$CANDIDATE_DIGEST" \
       --sync-policy-version "$SYNC_POLICY_VERSION" \
+      --processed-chunk-count "$PROCESSED_CHUNK_COUNT" \
+      --deferred-candidate-count "$DEFERRED_CANDIDATE_COUNT" \
+      --rejected-candidate-count "$REJECTED_CANDIDATE_COUNT" \
       "${FINALIZE_LAST_SYNC_ARGS[@]}")"; then
       sync_apply write-finalize-failure --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" \
         --candidate-digest "$CANDIDATE_DIGEST" >/dev/null 2>&1 || true
@@ -800,7 +984,9 @@ sync_apply write-active --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" --operation
 finalize_output=""
 typeset -a FINALIZE_LAST_SYNC_ARGS
 FINALIZE_LAST_SYNC_ARGS=()
-[[ "$CANDIDATE_TRUNCATED" == "1" ]] || FINALIZE_LAST_SYNC_ARGS=(--last-sync "$START_TS")
+if [[ "$CANDIDATE_TRUNCATED" == "0" && "$DEFERRED_CANDIDATE_COUNT" == "0" && "$REJECTED_CANDIDATE_COUNT" == "0" ]]; then
+  FINALIZE_LAST_SYNC_ARGS=(--last-sync "$START_TS")
+fi
 if ! finalize_output="$(sync_apply finalize \
   --root "$DSH_MEMORY_ROOT" \
   --run-id "$RUN_ID" \
@@ -816,6 +1002,9 @@ if ! finalize_output="$(sync_apply finalize \
   --duration-ms "$DURATION_MS" \
   --candidate-digest "$CANDIDATE_DIGEST" \
   --sync-policy-version "$SYNC_POLICY_VERSION" \
+  --processed-chunk-count "$PROCESSED_CHUNK_COUNT" \
+  --deferred-candidate-count "$DEFERRED_CANDIDATE_COUNT" \
+  --rejected-candidate-count "$REJECTED_CANDIDATE_COUNT" \
   "${FINALIZE_LAST_SYNC_ARGS[@]}")"; then
   sync_apply write-finalize-failure --root "$DSH_MEMORY_ROOT" --run-id "$RUN_ID" \
     --candidate-digest "$CANDIDATE_DIGEST" >/dev/null 2>&1 || true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-git-memory",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-git-memory",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "workspaces": [
         "packages/dsh-memory",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-git-memory",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-git-memory",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "workspaces": [
         "packages/dsh-memory",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-git-memory",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-git-memory",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "license": "MIT",
       "workspaces": [
         "packages/dsh-memory",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-git-memory",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": false,
   "description": "A local Git-backed long-term memory bundle for DeepSeek Harness",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-git-memory",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": false,
   "description": "A local Git-backed long-term memory bundle for DeepSeek Harness",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-git-memory",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "private": false,
   "description": "A local Git-backed long-term memory bundle for DeepSeek Harness",
   "type": "module",

--- a/packages/dsh-git-memory/client/client.js
+++ b/packages/dsh-git-memory/client/client.js
@@ -306,6 +306,15 @@ window.__ModuleLoader__.load({
               }
             };
             const unavailable = snapshot.status === "error" ? `长期记忆服务未就绪，暂不能修改（${snapshot.error ?? "settings-unavailable"}）` : snapshot.status === "loading" ? "正在读取长期记忆设置…" : "长期记忆设置不可写";
+            // Metadata anomalies are a data-quality warning surfaced separately
+            // from the repository health line; they never merge into recovery
+            // states on the host side either.
+            const metadataAnomaly = repository?.value && repository.value.metadataValid === false
+              ? {
+                  count: repository.value.invalidMetadataCount ?? 0,
+                  paths: (repository.value.invalidMetadata ?? []).slice(0, 5).map((entry) => entry.path),
+                }
+              : null;
             const repositoryStatus = repository?.error
               ? { tone: "danger", text: `记忆库不可用：${repository.error}`, error: true }
               : repository?.value
@@ -347,6 +356,14 @@ window.__ModuleLoader__.load({
                       jsx.jsx("span", { className: `dshmu_dot dshmu_dot--${repositoryStatus.tone}`, "aria-hidden": "true" }),
                       jsx.jsx("span", { children: repositoryStatus.text }),
                     ] }),
+              ] }) }) }),
+              metadataAnomaly !== null && jsx.jsx("section", { className: "dshmu_row", "aria-label": "记忆数据格式异常", children: jsx.jsx("div", { className: "dshmu_head dshmu_head--static", children: jsx.jsxs("div", { className: "dshmu_headMain", children: [
+                jsx.jsx("div", { className: "dshmu_title", children: "记忆数据格式异常" }),
+                jsx.jsxs("div", { className: "dshmu_statusLine dshmu_statusLine--error", children: [
+                  jsx.jsx("span", { className: "dshmu_dot dshmu_dot--warning", "aria-hidden": "true" }),
+                  jsx.jsx("span", { children: `${metadataAnomaly.count} 条记录的元数据无效；这些记录已从检索中排除，不影响其余记忆的使用与同步` }),
+                ] }),
+                metadataAnomaly.paths.length > 0 && jsx.jsx("span", { className: "dshmu_desc", children: metadataAnomaly.paths.join("、") }),
               ] }) }) }),
               repository !== null && jsx.jsxs("section", { className: "dshmu_row", "aria-label": "最近同步", onKeyDown: rowKeyDown("sync"), children: [
                 lastRun === null

--- a/packages/dsh-git-memory/lib/index.js
+++ b/packages/dsh-git-memory/lib/index.js
@@ -24,6 +24,13 @@ import { parseFrontMatter, isExpired, topicKey, auditRecords, AUDIT_INVALID_META
 import { legacyId, legacyRecordSummary, migratedContent, scanLegacyRecords } from "./legacy-migration.js";
 import { contentHashOf, formatCitation, readUsage, recordUsage, sortByUsage, usageMetadata } from "./memory-usage.js";
 import { SyncTransaction } from "./sync-transaction.js";
+import {
+  buildSearchIndex,
+  closeSearchIndex,
+  openSearchIndex,
+  querySearchIndex,
+  stampOf,
+} from "./search-index.js";
 
 const execFile = promisify(execFileCallback);
 const NS = settingsNamespace("memory");
@@ -42,6 +49,45 @@ const PYTHON_CANDIDATES = Object.freeze([
   "python3",
 ].filter(Boolean));
 const Config = z.object({ enabled: z.boolean().default(true) });
+
+/**
+ * v0.9.0 hybrid ranking: reciprocal-rank fusion over the raw lexical scan
+ * (weight 2.0), the FTS match rank and token coverage (1.0 each), and the
+ * usage order (0.25). Records containing the full query as an exact
+ * substring form a priority tier above the fused order.
+ */
+function fuseSearchResults(candidates, usage, query) {
+  const usageOrder = sortByUsage(candidates, usage);
+  const rawRank = new Map(candidates.map((entry, index) => [entry.path, index + 1]));
+  const usageRank = new Map(usageOrder.map((entry, index) => [entry.path, index + 1]));
+  const coverageRankEntries = candidates
+    .filter((entry) => (entry.__coverage ?? 0) > 0)
+    .sort((left, right) => (right.__coverage - left.__coverage)
+      || String(left.path).localeCompare(String(right.path)));
+  const coverageRank = new Map(coverageRankEntries.map((entry, index) => [entry.path, index + 1]));
+  const queryLower = String(query).trim().toLowerCase();
+  for (const entry of candidates) {
+    const ftsRank = entry.__ftsRank;
+    const covRank = coverageRank.get(entry.path);
+    const componentRaw = 2.0 / (60 + (rawRank.get(entry.path) ?? candidates.length));
+    const componentFts = ftsRank === undefined ? 0 : 1.0 / (60 + ftsRank);
+    const componentCoverage = covRank === undefined ? 0 : 1.0 / (60 + covRank);
+    const componentUsage = 0.25 / (60 + (usageRank.get(entry.path) ?? candidates.length));
+    entry.score_components = {
+      raw: componentRaw,
+      fts: componentFts,
+      coverage: componentCoverage,
+      usage: componentUsage,
+    };
+    entry.score = componentRaw + componentFts + componentCoverage + componentUsage;
+    entry.__tier = queryLower.length > 0 && typeof entry.__bodyLower === "string"
+      && entry.__bodyLower.includes(queryLower) ? 0 : 1;
+  }
+  return [...candidates].sort((left, right) => left.__tier - right.__tier
+    || right.score - left.score
+    || String(left.path).localeCompare(String(right.path)));
+}
+
 // Single-writer contract: ordinary sessions treat the memory repository as
 // read-only. Persistence happens exclusively through the periodic
 // transactional sync (dsh-memory-sync), which stages model output, verifies
@@ -846,22 +892,26 @@ export class MemoryRepository {
     }
   }
 
-  async collectSearchResults(root, query, includeArchive = false, usage = undefined, warnings = undefined) {
-    const tokens = query.toLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 0);
-    if (tokens.length === 0) throw memoryError("search-invalid-request");
-    const results = [];
+  /**
+   * v0.9.0: one pass over the payload produces the raw lexical ranking AND
+   * the record descriptors the derived index is built from. All eligible
+   * records (including archive) are returned so the index always covers the
+   * full payload; scope filtering happens on the fused candidates. Invalid
+   * metadata is excluded from results but never silently dropped: the caller
+   * returns it as warnings next to the results.
+   */
+  async scanRecords(root, usage) {
+    const records = [];
+    const warnings = [];
     const files = await this.payloadFiles(root);
     for (const file of files) {
       if (file === "summary.md" || !/\.md$/.test(file)) continue;
-      if (!includeArchive && file.startsWith("archive/")) continue;
       const content = await readFileSafe(join(root, file), "utf8").catch(() => "");
       let metadata = null;
       try {
         metadata = parseFrontMatter(content, file);
       } catch (error) {
-        // Invalid metadata is excluded from results but never silently
-        // dropped: the caller returns it as a warning next to the results.
-        warnings?.push({ path: file, code: error instanceof MetadataError ? error.code : "invalid-metadata" });
+        warnings.push({ path: file, code: error instanceof MetadataError ? error.code : "invalid-metadata" });
         continue;
       }
       if (metadata !== null && isExpired(metadata)) continue;
@@ -876,33 +926,148 @@ export class MemoryRepository {
         metadata?.source_hash ?? "",
         body,
       ].join("\n").toLowerCase();
-      let score = 0;
-      for (const token of tokens) {
-        if (searchable.includes(token)) score += 1;
-        if (recordId.toLowerCase().includes(token)) score += 3;
-        if ((metadata?.type ?? "").toLowerCase() === token) score += 2;
-        if (body.toLowerCase().includes(token)) score += 1;
-      }
-      if (score > 0) {
-        const lower = body.toLowerCase();
-        const first = lower.indexOf(tokens[0]);
-        const snippet = first === -1 ? body.slice(0, 160) : body.slice(Math.max(0, first - 40), first + 120).replace(/\s+/g, " ").trim();
-        results.push({
-          path: file,
-          score,
-          id: recordId,
-          type: metadata?.type ?? null,
-          updated_at: metadata?.updated_at ?? null,
-          content_hash: usageInfo.content_hash ?? contentHashOf(content),
-          generation: usageInfo.generation,
-          source_rollouts: metadata?.source_rollouts ?? [],
-          source_session_digest: metadata?.source_session_digest ?? null,
-          snippet,
-          citation: formatCitation(file, recordId),
-        });
-      }
+      const bodyLower = body.toLowerCase();
+      records.push({
+        path: file,
+        id: recordId,
+        type: metadata?.type ?? null,
+        tags: metadata?.tags ?? [],
+        updatedAt: metadata?.updated_at ?? null,
+        rawBody: body,
+        searchable,
+        content_hash: usageInfo.content_hash ?? contentHashOf(content),
+        generation: usageInfo.generation,
+        source_rollouts: metadata?.source_rollouts ?? [],
+        source_session_digest: metadata?.source_session_digest ?? null,
+        citation: formatCitation(file, recordId),
+        __bodyLower: bodyLower,
+        __searchable: searchable,
+      });
     }
-    return results.sort((left, right) => right.score - left.score || String(left.path).localeCompare(String(right.path)));
+    return { records, warnings };
+  }
+
+  /** Raw lexical score of one record against the tokenized query. */
+  rawLexicalScore(record, tokens) {
+    let score = 0;
+    for (const token of tokens) {
+      if (record.__searchable.includes(token)) score += 1;
+      if (record.id.toLowerCase().includes(token)) score += 3;
+      if ((record.type ?? "").toLowerCase() === token) score += 2;
+      if (record.__bodyLower.includes(token)) score += 1;
+    }
+    return score;
+  }
+
+  /** Backwards-compatible raw scan: scored, sorted, archive-filtered. */
+  async collectSearchResults(root, query, includeArchive = false, usage = undefined, warnings = undefined) {
+    const tokens = query.toLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 0);
+    if (tokens.length === 0) throw memoryError("search-invalid-request");
+    const { records, warnings: scanWarnings } = await this.scanRecords(root, usage);
+    const results = [];
+    for (const record of records) {
+      const score = this.rawLexicalScore(record, tokens);
+      if (score <= 0) continue;
+      const first = record.__bodyLower.indexOf(tokens[0]);
+      const snippet = first === -1 ? record.rawBody.slice(0, 160) : record.rawBody.slice(Math.max(0, first - 40), first + 120).replace(/\s+/g, " ").trim();
+      results.push({
+        path: record.path,
+        score,
+        id: record.id,
+        type: record.type,
+        updated_at: record.updatedAt,
+        content_hash: record.content_hash,
+        generation: record.generation,
+        source_rollouts: record.source_rollouts,
+        source_session_digest: record.source_session_digest,
+        snippet,
+        citation: record.citation,
+      });
+    }
+    results.sort((left, right) => right.score - left.score || String(left.path).localeCompare(String(right.path)));
+    if (warnings !== undefined) warnings.push(...(includeArchive ? scanWarnings : scanWarnings.filter((w) => !w.path.startsWith("archive/"))));
+    return includeArchive ? results : results.filter((entry) => !entry.path.startsWith("archive/"));
+  }
+
+  /**
+   * v0.9.0 hybrid retrieval shared by memory_search and memory_context:
+   * raw scan candidates fused with the derived SQLite index signals
+   * (FTS rank + token coverage) and usage order; exact-substring hits form
+   * the top tier. Falls back to the pure scan ranking — marked degraded —
+   * when the index is unavailable.
+   */
+  async retrieve(root, query, scope, usage, warnings) {
+    const inScope = scope === "archive"
+      ? (path) => path.startsWith("archive/")
+      : scope === "active"
+        ? (path) => !path.startsWith("archive/")
+        : () => true;
+    const { records, warnings: scanWarnings } = await this.scanRecords(root, usage);
+    warnings.push(...scanWarnings.filter((warning) => inScope(warning.path)));
+    const candidates = records.filter((record) => inScope(record.path));
+    const tokens = query.toLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 0);
+    if (tokens.length === 0) throw memoryError("search-invalid-request");
+    for (const record of candidates) {
+      const score = this.rawLexicalScore(record, tokens);
+      record.__rawScore = score;
+      const first = record.__bodyLower.indexOf(tokens[0]);
+      record.__snippet = first === -1 ? record.rawBody.slice(0, 160) : record.rawBody.slice(Math.max(0, first - 40), first + 120).replace(/\s+/g, " ").trim();
+    }
+    let retrieval = { mode: "scan", indexState: "degraded", stamp: null };
+    let fts = null;
+    try {
+      const stamp = stampOf(await this.payloadTree("HEAD"));
+      let handle = null;
+      let needsBuild = true;
+      let indexState = "rebuilt";
+      try {
+        handle = await openSearchIndex(root, stamp);
+        if (handle !== null && handle.stampMatches) {
+          needsBuild = false;
+          indexState = "fresh";
+        } else if (handle !== null) {
+          closeSearchIndex(handle);
+          handle = null;
+        }
+      } catch {
+        handle = null;
+      }
+      if (needsBuild) {
+        await buildSearchIndex(root, records, stamp, scanWarnings);
+        handle = await openSearchIndex(root, stamp);
+        if (handle === null) throw new Error("search-index missing after build");
+      }
+      try {
+        fts = querySearchIndex(handle.db, query);
+      } finally {
+        closeSearchIndex(handle);
+      }
+      retrieval = { mode: "hybrid", indexState, stamp };
+    } catch {
+      fts = null;
+      retrieval = { mode: "scan", indexState: "degraded", stamp: null };
+    }
+    for (const record of candidates) {
+      record.__ftsRank = fts?.ranksByPath.get(record.path);
+      record.__coverage = fts?.coverageByPath.get(record.path) ?? 0;
+    }
+    const scored = candidates.filter((record) => record.__rawScore > 0);
+    const ranked = fuseSearchResults(scored, usage, query);
+    const candidates_ = ranked.map((entry) => ({
+      path: entry.path,
+      score: entry.score,
+      id: entry.id,
+      type: entry.type,
+      updated_at: entry.updatedAt,
+      content_hash: entry.content_hash,
+      generation: entry.generation,
+      source_rollouts: entry.source_rollouts,
+      source_session_digest: entry.source_session_digest,
+      snippet: entry.__snippet,
+      citation: entry.citation,
+      score_components: entry.score_components,
+    }));
+    return { candidates: candidates_, recordsForIndex: records, retrieval };
   }
 
   /**
@@ -921,9 +1086,8 @@ export class MemoryRepository {
     try {
       const usage = await readUsage(root);
       const warnings = [];
-      const results = (await this.collectSearchResults(root, request.query, scope !== "active", usage, warnings))
-        .filter((entry) => scope !== "archive" || entry.path.startsWith("archive/"));
-      return success({ query: request.query, count: results.length, results: results.slice(0, limit), warnings });
+      const { candidates, retrieval } = await this.retrieve(root, request.query, scope, usage, warnings);
+      return success({ query: request.query, count: candidates.length, results: candidates.slice(0, limit), warnings, retrieval });
     } catch (error) {
       return failure(error?.memoryCode ?? "search-failed");
     }
@@ -947,8 +1111,11 @@ export class MemoryRepository {
       const usage = await readUsage(root);
       const warnings = [];
       let candidates;
+      let retrieval = null;
       if (hasQuery) {
-        candidates = sortByUsage(await this.collectSearchResults(root, request.query, scope !== "active", usage, warnings), usage).slice(0, limit);
+        const fused = await this.retrieve(root, request.query, scope, usage, warnings);
+        candidates = fused.candidates.slice(0, limit);
+        retrieval = fused.retrieval;
       } else {
         candidates = [];
         for (const file of await this.payloadFiles(root)) {
@@ -1000,7 +1167,7 @@ export class MemoryRepository {
           prior_usage_count: metadata.prior_usage_count,
           source_rollouts: entry.source_rollouts ?? [],
           source_session_digest: entry.source_session_digest ?? null,
-          ...(hasQuery ? { score: entry.score } : {}),
+          ...(hasQuery ? { score: entry.score, score_components: entry.score_components } : {}),
         });
       }
       return success({
@@ -1008,6 +1175,7 @@ export class MemoryRepository {
         count: records.length,
         records,
         warnings,
+        ...(hasQuery ? { retrieval } : {}),
       });
     } catch (error) {
       return failure(error?.memoryCode ?? "context-failed");

--- a/packages/dsh-git-memory/lib/index.js
+++ b/packages/dsh-git-memory/lib/index.js
@@ -143,7 +143,7 @@ function startSummaryWatcher(onChange) {
     lastSeen = { mtimeMs: stat.mtimeMs, size: stat.size };
   } catch {}
   let debounceTimer = null;
-  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS }, (current) => {
+  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS, persistent: false }, (current) => {
     // A zeroed stat means the file is temporarily gone; the snapshot
     // retention in buildMemorySectionText covers it, so do not refresh.
     if (!current || (current.size === 0 && current.mtimeMs === 0)) return;

--- a/packages/dsh-git-memory/lib/index.js
+++ b/packages/dsh-git-memory/lib/index.js
@@ -1,6 +1,7 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { homedir, tmpdir } from "node:os";
+import { statSync, watchFile, unwatchFile } from "node:fs";
 import { copyFile, lstat, mkdir, mkdtemp, readFile, realpath, rm, rmdir, unlink, writeFile } from "node:fs/promises";
 import { join, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,7 +20,7 @@ import {
   releaseOperationLock,
   writeActiveRun,
 } from "./operation-lock.js";
-import { parseFrontMatter, isExpired, topicKey } from "./memory-metadata.js";
+import { parseFrontMatter, isExpired, topicKey, auditRecords, AUDIT_INVALID_METADATA_LIMIT, MetadataError } from "./memory-metadata.js";
 import { legacyId, legacyRecordSummary, migratedContent, scanLegacyRecords } from "./legacy-migration.js";
 import { contentHashOf, formatCitation, readUsage, recordUsage, sortByUsage, usageMetadata } from "./memory-usage.js";
 import { SyncTransaction } from "./sync-transaction.js";
@@ -41,24 +42,38 @@ const PYTHON_CANDIDATES = Object.freeze([
   "python3",
 ].filter(Boolean));
 const Config = z.object({ enabled: z.boolean().default(true) });
+// Single-writer contract: ordinary sessions treat the memory repository as
+// read-only. Persistence happens exclusively through the periodic
+// transactional sync (dsh-memory-sync), which stages model output, verifies
+// it host-side, and commits it. No session ever runs git or writes to the
+// live repository directly.
 const MEMORY_SECTION = `长期记忆已开启（DPSK 专属仓库 ${DEFAULT_MEMORY_ROOT}，git 版本化；操作手册见 memory 技能）。
 
 自动行为，用户无需提醒：
 1. 每个任务动手前：先读下方 <summary_snapshot>（summary.md 的启动快照），需要细节时用 memory_search / memory_context 工具或 grep handbook/ 检索；命中则遵循，无命中直接开始，不要向用户询问"要不要回忆"。
-2. 完成重要任务或会话收尾时：自动用子代理执行记忆提取（extract → rollouts/）与整合（consolidate → handbook/ 与 summary.md），随后在仓库内 git add -A && git commit。
-3. 用户纠正偏好或告知新约定时：立即更新对应记忆条目。
+2. 普通会话对记忆库只读：不要直接写记忆文件，不要执行任何 git 命令。若本会话产生了值得沉淀的结论，把它作为记忆请求记录在自己的回复或会话中（说明建议归入 handbook/ 或 rollouts/ 的要点）；周期性事务同步（dsh-memory-sync）会在后台完成提取、整合与提交。
+3. 用户纠正偏好或告知新约定时：按第 2 条记录记忆请求；不要当场改写记忆条目。
 
 硬规则：只存证据化结论；禁存凭据（写入 [REDACTED]）；原始会话日志只读；宁缺毋滥。
 `;
 
 export const SUMMARY_BUDGET_BYTES = 12 * 1024;
 const SUMMARY_INJECT_MAX_BYTES = SUMMARY_BUDGET_BYTES;
+// Prompt freshness: the injected summary snapshot must track edits to
+// summary.md without waiting for a settings change. The host polls the file
+// every few seconds; an mtime/size change triggers one debounced async
+// refresh. While the file is briefly missing or unreadable the previous
+// valid snapshot is retained — the prompt is never cleared by a transient
+// read failure.
+let lastSummarySnapshot = null;
 async function buildMemorySectionText() {
   let summary;
   try {
     summary = await readFile(join(DEFAULT_MEMORY_ROOT, "summary.md"), "utf8");
+    lastSummarySnapshot = summary;
   } catch {
-    return MEMORY_SECTION;
+    if (lastSummarySnapshot === null) return MEMORY_SECTION;
+    summary = lastSummarySnapshot;
   }
   const bounded = boundedContextBody(summary, SUMMARY_INJECT_MAX_BYTES);
   const note = bounded.truncated
@@ -69,6 +84,36 @@ async function buildMemorySectionText() {
 <summary_snapshot>
 ${bounded.content}${note}
 </summary_snapshot>`;
+}
+
+const SUMMARY_WATCH_INTERVAL_MS = 5000;
+const SUMMARY_REFRESH_DEBOUNCE_MS = 1000;
+/** Poll summary.md and invoke onChange (debounced) after mtime/size changes. */
+function startSummaryWatcher(onChange) {
+  const summaryPath = join(DEFAULT_MEMORY_ROOT, "summary.md");
+  let lastSeen = null;
+  try {
+    const stat = statSync(summaryPath);
+    lastSeen = { mtimeMs: stat.mtimeMs, size: stat.size };
+  } catch {}
+  let debounceTimer = null;
+  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS }, (current) => {
+    // A zeroed stat means the file is temporarily gone; the snapshot
+    // retention in buildMemorySectionText covers it, so do not refresh.
+    if (!current || (current.size === 0 && current.mtimeMs === 0)) return;
+    if (lastSeen && current.mtimeMs === lastSeen.mtimeMs && current.size === lastSeen.size) return;
+    lastSeen = { mtimeMs: current.mtimeMs, size: current.size };
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      try { onChange(); } catch {}
+    }, SUMMARY_REFRESH_DEBOUNCE_MS);
+  });
+  return () => {
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = null;
+    unwatchFile(summaryPath);
+  };
 }
 
 export const name = "dsh-memory";
@@ -300,6 +345,7 @@ export class MemoryRepository {
       const { dataFileCount } = await safeClear(root, "inspect");
       const targetDirty = (await this.git(["status", "--porcelain", "--", ...TARGETS])).stdout.trim().length > 0;
       const { legacyFileCount, pendingMigration } = await this.metadataStats(root);
+      const audit = await this.metadataAudit(root);
       const lastRun = await this.readLastRun(root);
       const retrySuppressed = await this.readRetrySuppressed(root);
       const summaryBytes = await this.summaryBytes(root);
@@ -314,6 +360,10 @@ export class MemoryRepository {
         schemaVersion: 1,
         legacyFileCount,
         pendingMigration,
+        metadataValid: audit.metadataValid,
+        validMetadataCount: audit.validMetadataCount,
+        invalidMetadataCount: audit.invalidMetadataCount,
+        invalidMetadata: audit.invalidMetadata,
         lastRun,
         retrySuppressed,
         summaryBytes,
@@ -356,6 +406,7 @@ export class MemoryRepository {
       const summaryBytes = await this.summaryBytes(root);
       const failureSentinel = await this.readFailureSentinel(root);
       const finalizeFailure = await this.readFinalizeFailure(root);
+      const audit = await this.metadataAudit(root);
       const interruptedRun = activeState === "interrupted"
         ? activeRun
         : (await this.readLastRun(root))?.status === "interrupted" ? await this.readLastRun(root) : null;
@@ -371,6 +422,10 @@ export class MemoryRepository {
         finalizeFailure,
         retrySuppressed,
         payloadDirty,
+        metadataValid: audit.metadataValid,
+        validMetadataCount: audit.validMetadataCount,
+        invalidMetadataCount: audit.invalidMetadataCount,
+        invalidMetadata: audit.invalidMetadata,
         operationLock: operationLock === null ? null : {
           operation: operationLock.operation ?? null,
           pid: operationLock.pid ?? null,
@@ -383,6 +438,8 @@ export class MemoryRepository {
         pendingPreview: previews[0] ?? null,
         pendingPreviewCount: previews.length,
         journalReadable,
+        // Metadata anomalies are a data-quality warning, not a recovery
+        // blocker: reads and the periodic sync keep working around them.
         needsManualRecovery: payloadDirty || activeState === "interrupted" || interruptedRun !== null || !journalReadable
           || summaryBytes > SUMMARY_BUDGET_BYTES || (failureSentinel?.consecutive_failures ?? 0) >= 3
           || finalizeFailure !== null,
@@ -404,6 +461,27 @@ export class MemoryRepository {
     } catch {
       return { legacyFileCount: 0, pendingMigration: false };
     }
+  }
+
+  /** Record-shaped payload files eligible for the metadata audit. */
+  async recordFiles(root) {
+    return (await this.payloadFiles(root)).filter((file) => file !== "summary.md" && /\.md$/.test(file));
+  }
+
+  /**
+   * Shared metadata audit (report-only). Structured records are validated
+   * against schema v1; duplicate ids and unreadable files are reported.
+   * Metadata anomalies never block reads here and are deliberately not part
+   * of needsManualRecovery — the UI surfaces them as a separate warning.
+   */
+  async metadataAudit(root) {
+    const files = await this.recordFiles(root);
+    const records = [];
+    for (const file of files) {
+      const content = await readFileSafe(join(root, file), "utf8").catch(() => null);
+      records.push({ path: file, content });
+    }
+    return auditRecords(records);
   }
 
   async summaryBytes(root) {
@@ -768,7 +846,7 @@ export class MemoryRepository {
     }
   }
 
-  async collectSearchResults(root, query, includeArchive = false, usage = undefined) {
+  async collectSearchResults(root, query, includeArchive = false, usage = undefined, warnings = undefined) {
     const tokens = query.toLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 0);
     if (tokens.length === 0) throw memoryError("search-invalid-request");
     const results = [];
@@ -778,7 +856,14 @@ export class MemoryRepository {
       if (!includeArchive && file.startsWith("archive/")) continue;
       const content = await readFileSafe(join(root, file), "utf8").catch(() => "");
       let metadata = null;
-      try { metadata = parseFrontMatter(content, file); } catch { continue; }
+      try {
+        metadata = parseFrontMatter(content, file);
+      } catch (error) {
+        // Invalid metadata is excluded from results but never silently
+        // dropped: the caller returns it as a warning next to the results.
+        warnings?.push({ path: file, code: error instanceof MetadataError ? error.code : "invalid-metadata" });
+        continue;
+      }
       if (metadata !== null && isExpired(metadata)) continue;
       const recordId = metadata?.id ?? legacyId(file);
       const usageInfo = usageMetadata(file, usage);
@@ -835,9 +920,10 @@ export class MemoryRepository {
     try { root = await this.inspect(); } catch (error) { return failure(error?.memoryCode ?? "repo-unavailable"); }
     try {
       const usage = await readUsage(root);
-      const results = (await this.collectSearchResults(root, request.query, scope !== "active", usage))
+      const warnings = [];
+      const results = (await this.collectSearchResults(root, request.query, scope !== "active", usage, warnings))
         .filter((entry) => scope !== "archive" || entry.path.startsWith("archive/"));
-      return success({ query: request.query, count: results.length, results: results.slice(0, limit) });
+      return success({ query: request.query, count: results.length, results: results.slice(0, limit), warnings });
     } catch (error) {
       return failure(error?.memoryCode ?? "search-failed");
     }
@@ -859,9 +945,10 @@ export class MemoryRepository {
     try { root = await this.inspect(); } catch (error) { return failure(error?.memoryCode ?? "repo-unavailable"); }
     try {
       const usage = await readUsage(root);
+      const warnings = [];
       let candidates;
       if (hasQuery) {
-        candidates = sortByUsage(await this.collectSearchResults(root, request.query, scope !== "active", usage), usage).slice(0, limit);
+        candidates = sortByUsage(await this.collectSearchResults(root, request.query, scope !== "active", usage, warnings), usage).slice(0, limit);
       } else {
         candidates = [];
         for (const file of await this.payloadFiles(root)) {
@@ -870,7 +957,12 @@ export class MemoryRepository {
           if (scope === "archive" && !file.startsWith("archive/")) continue;
           const content = await readFileSafe(join(root, file), "utf8").catch(() => "");
           let metadata = null;
-          try { metadata = parseFrontMatter(content, file); } catch { continue; }
+          try {
+            metadata = parseFrontMatter(content, file);
+          } catch (error) {
+            warnings?.push({ path: file, code: error instanceof MetadataError ? error.code : "invalid-metadata" });
+            continue;
+          }
           if (metadata !== null && isExpired(metadata)) continue;
           const recordId = metadata?.id ?? legacyId(file);
           candidates.push({
@@ -915,6 +1007,7 @@ export class MemoryRepository {
         query: hasQuery ? request.query : null,
         count: records.length,
         records,
+        warnings,
       });
     } catch (error) {
       return failure(error?.memoryCode ?? "context-failed");
@@ -1220,6 +1313,11 @@ export function apply(ctx, entry) {
     };
     refreshPrompt = refresh;
     refresh();
-    promptCtx.effect(() => () => { if (refreshPrompt === refresh) refreshPrompt = () => {}; disposeSection?.(); }, "dsh-memory: section cleanup");
+    const stopSummaryWatcher = startSummaryWatcher(refresh);
+    promptCtx.effect(() => () => {
+      stopSummaryWatcher();
+      if (refreshPrompt === refresh) refreshPrompt = () => {};
+      disposeSection?.();
+    }, "dsh-memory: section cleanup");
   });
 }

--- a/packages/dsh-git-memory/lib/memory-metadata.js
+++ b/packages/dsh-git-memory/lib/memory-metadata.js
@@ -105,6 +105,12 @@ function parseBlock(block) {
     const key = line.slice(0, colon).trim();
     const value = line.slice(colon + 1).trim();
     if (key === "") throw new MetadataError("invalid-metadata", "front matter has an empty key");
+    // Canonical records use block lists (tags:\n  - item). Flow-style
+    // collections are rejected with a stable code so the staging validator and
+    // the metadata audit report the same, actionable diagnosis.
+    if ((value.startsWith("[") && value !== "[]") || (value.startsWith("{") && value !== "{}")) {
+      throw new MetadataError("flow-style-metadata", `${key} must use a canonical block list, not a flow collection`);
+    }
     currentKey = key;
     if (value === "" || value.startsWith("|") || value.startsWith(">")) {
       // A nested mapping or block scalar is not part of the record contract.
@@ -277,4 +283,77 @@ export function resolveTopicConflict(records, now = Date.now()) {
     if (dateDiff !== 0) return dateDiff;
     return String(left.id).localeCompare(String(right.id));
   })[0];
+}
+
+export const AUDIT_INVALID_METADATA_LIMIT = 20;
+
+/**
+ * Shared metadata audit over structured records (schema_version 1).
+ *
+ * Scans every record-shaped payload document and reports:
+ *   - per-file validation failures (schema, fields, duplicate ids);
+ *   - legacy records (no front matter) which are counted but never invalid;
+ *   - duplicate structured ids across the corpus.
+ *
+ * The audit is report-only: callers decide whether invalid metadata blocks a
+ * write path (staging validation stays fail-closed) or only surfaces in
+ * status/health and search warnings. Legacy records grandfather as valid.
+ *
+ * @param {Array<{ path: string, content: string }>} records
+ * @returns {{ metadataValid: boolean, validMetadataCount: number, invalidMetadataCount: number, legacyMetadataCount: number, duplicateIdCount: number, invalidMetadata: Array<{ path: string, code: string }> }}
+ */
+export function auditRecords(records) {
+  let validCount = 0;
+  let legacyCount = 0;
+  const invalid = [];
+  let invalidCount = 0;
+  const seenIds = new Map();
+  let duplicateIdCount = 0;
+  for (const record of records) {
+    if (record.content === null || record.content === undefined) {
+      // The file could not be read at all; that is an invalid record, not a
+      // legacy one, so it surfaces in the audit instead of disappearing.
+      invalidCount += 1;
+      if (invalid.length < AUDIT_INVALID_METADATA_LIMIT) invalid.push({ path: record.path, code: "unreadable" });
+      continue;
+    }
+    if (!hasRecordFrontMatter(record.content)) {
+      legacyCount += 1;
+      continue;
+    }
+    try {
+      const metadata = parseFrontMatter(record.content, record.path);
+      if (metadata === null) {
+        // Not a record path (defensive; callers pre-filter).
+        continue;
+      }
+      validCount += 1;
+      const first = seenIds.get(metadata.id);
+      if (first !== undefined) {
+        duplicateIdCount += 1;
+        invalidCount += 1;
+        if (invalid.length < AUDIT_INVALID_METADATA_LIMIT) {
+          invalid.push({ path: record.path, code: "duplicate-id" });
+        }
+      } else {
+        seenIds.set(metadata.id, record.path);
+      }
+    } catch (error) {
+      const code = error instanceof MetadataError ? error.code : "invalid-metadata";
+      invalidCount += 1;
+      if (invalid.length < AUDIT_INVALID_METADATA_LIMIT) invalid.push({ path: record.path, code });
+    }
+  }
+  return {
+    metadataValid: invalidCount === 0,
+    validMetadataCount: validCount,
+    invalidMetadataCount: invalidCount,
+    legacyMetadataCount: legacyCount,
+    duplicateIdCount,
+    invalidMetadata: invalid,
+  };
+}
+
+function hasRecordFrontMatter(content) {
+  return content.startsWith("---\n") || content.startsWith("---\r\n");
 }

--- a/packages/dsh-git-memory/lib/search-index.js
+++ b/packages/dsh-git-memory/lib/search-index.js
@@ -1,0 +1,241 @@
+// v0.9.0 derived SQLite search index.
+//
+// The index is a cache derived from the payload tree at HEAD; its validity
+// stamp is sha256(payloadTree(HEAD)) so every applied sync commit (which
+// changes HEAD) invalidates it. The database lives at .sync/search-index.sqlite
+// (mode 0600, git-excluded), is built into a temporary file and atomically
+// renamed into place, and is opened read-only on the query path. When SQLite
+// or FTS5 is unavailable, or the index cannot be built or read, callers fall
+// back to the full scan with retrieval.mode = "scan" and indexState =
+// "degraded"; search results stay correct, only the ranking components shrink.
+import { createHash, randomUUID } from "node:crypto";
+import { chmod, lstat, rename, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+export const SEARCH_INDEX_SCHEMA_VERSION = 1;
+export const SEARCH_INDEX_FILE = ".sync/search-index.sqlite";
+export const SEARCH_INDEX_TEMP_PREFIX = ".search-index.";
+export const SEARCH_INDEX_TEMP_SUFFIX = ".tmp";
+export const RRF_K = 60;
+export const RRF_WEIGHTS = Object.freeze({ raw: 2.0, fts: 1.0, coverage: 1.0, usage: 0.25 });
+
+const CJK_RUN = /[\u3400-\u4dbf\u4e00-\u9fff]+/g;
+const LATIN_WORD = /[a-z0-9_][a-z0-9_-]*/g;
+
+let sqlitePromise = null;
+
+async function loadSqlite() {
+  if (sqlitePromise === null) {
+    sqlitePromise = import("node:sqlite").then((module) => module.DatabaseSync);
+  }
+  return await sqlitePromise;
+}
+
+export async function isSqliteAvailable() {
+  try {
+    await loadSqlite();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** sha256 over "blob-object path" lines of the payload tree at a commit. */
+export function stampOf(payloadTreeText) {
+  return `sha256:${createHash("sha256").update(payloadTreeText, "utf8").digest("hex")}`;
+}
+
+/**
+ * Derived index terms for one record: lowercase latin words plus CJK
+ * character bigrams (a lone CJK character is kept as a unigram). The query
+ * side reuses this function so index and query token spaces always match.
+ */
+export function derivedTerms(text) {
+  const tokens = [];
+  const lower = String(text).toLowerCase();
+  for (const word of lower.match(LATIN_WORD) ?? []) tokens.push(word);
+  for (const run of String(text).match(CJK_RUN) ?? []) {
+    if (run.length === 1) {
+      tokens.push(run);
+      continue;
+    }
+    for (let index = 0; index < run.length - 1; index += 1) tokens.push(run.slice(index, index + 2));
+  }
+  return tokens.join(" ");
+}
+
+/** Split a query into the FTS signals the index can answer. */
+export function tokenizeQuery(query) {
+  const trimmed = String(query).trim();
+  const words = new Set();
+  const bigrams = new Set();
+  const phrases = [];
+  const lower = trimmed.toLowerCase();
+  for (const word of lower.match(LATIN_WORD) ?? []) {
+    if (word.length >= 2) words.add(word);
+    if (word.length >= 3) phrases.push(word);
+  }
+  for (const run of trimmed.match(CJK_RUN) ?? []) {
+    if (run.length >= 3) phrases.push(run);
+    if (run.length === 1) {
+      bigrams.add(run);
+      continue;
+    }
+    for (let index = 0; index < run.length - 1; index += 1) bigrams.add(run.slice(index, index + 2));
+  }
+  if ([...trimmed].length >= 3) phrases.push(trimmed);
+  return { words: [...words], bigrams: [...bigrams], phrases };
+}
+
+function ftsMatchOr(terms) {
+  return terms.map((term) => `"${term.replaceAll('"', '""')}"`).join(" OR ");
+}
+
+function ftsMatchPlain(terms) {
+  return terms.join(" OR ");
+}
+
+async function ensureIndexGitExcludes(root) {
+  const excludePath = join(root, ".git", "info", "exclude");
+  const current = await (await import("node:fs/promises")).readFile(excludePath, "utf8").catch(() => "");
+  const lines = current.split(/\r?\n/);
+  const wanted = [".sync/search-index.sqlite", `.sync/${SEARCH_INDEX_TEMP_PREFIX}*${SEARCH_INDEX_TEMP_SUFFIX}`];
+  const missing = wanted.filter((entry) => !lines.includes(entry));
+  if (missing.length === 0) return;
+  const suffix = current.length === 0 || current.endsWith("\n") ? "" : "\n";
+  const { writeFile } = await import("node:fs/promises");
+  await writeFile(excludePath, `${current}${suffix}${missing.join("\n")}\n`, { mode: 0o600 });
+  await chmod(excludePath, 0o600).catch(() => {});
+}
+
+/**
+ * Build the index from eligible records and atomically replace the previous
+ * database. `records` items: {path, id, type, tags, updatedAt, rawBody,
+ * searchable} — `searchable` is the raw-scan scoring text, `rawBody` the
+ * front-matter-free body used for snippets and exact-substring tiers.
+ */
+export async function buildSearchIndex(root, records, stamp, warnings = []) {
+  const DatabaseSync = await loadSqlite();
+  const syncRoot = join(root, ".sync");
+  const finalPath = join(syncRoot, "search-index.sqlite");
+  const temporary = join(syncRoot, `${SEARCH_INDEX_TEMP_PREFIX}${process.pid}.${randomUUID()}${SEARCH_INDEX_TEMP_SUFFIX}`);
+  let db;
+  try {
+    db = new DatabaseSync(temporary);
+    db.exec("PRAGMA journal_mode=DELETE;");
+    db.exec(`
+      CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+      CREATE TABLE records(
+        path TEXT PRIMARY KEY,
+        id TEXT,
+        type TEXT,
+        tags TEXT,
+        updated_at TEXT,
+        raw_body TEXT,
+        searchable TEXT
+      );
+      CREATE VIRTUAL TABLE content_fts USING fts5(path UNINDEXED, body, tokenize='trigram');
+      CREATE VIRTUAL TABLE terms_fts USING fts5(path UNINDEXED, terms, tokenize='unicode61');
+      CREATE TABLE invalid_metadata(path TEXT PRIMARY KEY, code TEXT NOT NULL);
+    `);
+    const insertRecord = db.prepare(
+      "INSERT INTO records(path, id, type, tags, updated_at, raw_body, searchable) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    );
+    const insertContent = db.prepare("INSERT INTO content_fts(path, body) VALUES (?, ?)");
+    const insertTerms = db.prepare("INSERT INTO terms_fts(path, terms) VALUES (?, ?)");
+    const insertWarning = db.prepare("INSERT INTO invalid_metadata(path, code) VALUES (?, ?)");
+    db.exec("BEGIN");
+    for (const record of records) {
+      const tags = JSON.stringify(record.tags ?? []);
+      insertRecord.run(record.path, record.id, record.type, tags, record.updatedAt, record.rawBody, record.searchable);
+      insertContent.run(record.path, record.searchable);
+      insertTerms.run(record.path, derivedTerms(record.searchable));
+    }
+    for (const warning of warnings) insertWarning.run(warning.path, warning.code);
+    db.exec("COMMIT");
+    db.exec(`
+      INSERT INTO meta(key, value) VALUES ('schema_version', '${SEARCH_INDEX_SCHEMA_VERSION}');
+      INSERT INTO meta(key, value) VALUES ('stamp', '${stamp.replaceAll("'", "''")}');
+      INSERT INTO meta(key, value) VALUES ('built_at', '${new Date().toISOString()}');
+    `);
+    db.close();
+    db = undefined;
+    await chmod(temporary, 0o600);
+    await rename(temporary, finalPath);
+    await chmod(finalPath, 0o600).catch(() => {});
+    await ensureIndexGitExcludes(root).catch(() => {});
+  } catch (error) {
+    try { db?.close(); } catch {}
+    await rm(temporary, { force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+/**
+ * Open the index read-only. Returns:
+ *   { db, stampMatches }         — database opened
+ *   null                         — no index file present
+ * and throws on a corrupt or schema-mismatched database (caller rebuilds).
+ */
+export async function openSearchIndex(root, expectedStamp) {
+  const path = join(root, SEARCH_INDEX_FILE);
+  const stat = await lstat(path).catch((error) => {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  });
+  if (stat === null) return null;
+  if (stat.isSymbolicLink() || !stat.isFile()) throw new Error("search-index: unsafe layout");
+  const DatabaseSync = await loadSqlite();
+  const db = new DatabaseSync(path, { readOnly: true });
+  try {
+    const schemaVersion = db.prepare("SELECT value FROM meta WHERE key = 'schema_version'").get()?.value;
+    if (Number(schemaVersion) !== SEARCH_INDEX_SCHEMA_VERSION) throw new Error("search-index: schema mismatch");
+    const stamp = db.prepare("SELECT value FROM meta WHERE key = 'stamp'").get()?.value ?? "";
+    return { db, stampMatches: stamp === expectedStamp };
+  } catch (error) {
+    try { db.close(); } catch {}
+    throw error;
+  }
+}
+
+/**
+ * Query the index. Returns { ranksByPath, coverageByPath, stamp } where
+ * ranksByPath is a 1-based best-effort FTS rank (trigram matches first, then
+ * term matches) and coverageByPath maps paths to the fraction of query tokens
+ * matched. Returns null when the query produces no usable FTS signals.
+ */
+export function querySearchIndex(db, query) {
+  const { words, bigrams, phrases } = tokenizeQuery(query);
+  const ranksByPath = new Map();
+  const coverageTokens = new Map();
+  const totalTokens = words.length + bigrams.length;
+  const consider = (list) => {
+    for (const path of list) if (!ranksByPath.has(path)) ranksByPath.set(path, ranksByPath.size + 1);
+  };
+  if (phrases.length > 0) {
+    const rows = db.prepare("SELECT path, bm25(content_fts) AS r FROM content_fts WHERE content_fts MATCH ? ORDER BY r").all(ftsMatchOr(phrases));
+    consider(rows.map((row) => row.path));
+  }
+  if (words.length > 0 || bigrams.length > 0) {
+    const termTokens = [...words, ...bigrams];
+    for (const token of termTokens) {
+      const rows = db.prepare("SELECT path FROM terms_fts WHERE terms_fts MATCH ?").all(ftsMatchPlain([token]));
+      for (const row of rows) {
+        if (!coverageTokens.has(row.path)) coverageTokens.set(row.path, new Set());
+        coverageTokens.get(row.path).add(token);
+      }
+    }
+    const rows = db.prepare("SELECT path, bm25(terms_fts) AS r FROM terms_fts WHERE terms_fts MATCH ? ORDER BY r").all(ftsMatchPlain(termTokens));
+    consider(rows.map((row) => row.path));
+  }
+  const coverageByPath = new Map();
+  for (const [path, matched] of coverageTokens) {
+    coverageByPath.set(path, totalTokens === 0 ? 0 : matched.size / totalTokens);
+  }
+  return { ranksByPath, coverageByPath };
+}
+
+/** Close a handle returned by openSearchIndex. */
+export function closeSearchIndex(handle) {
+  try { handle?.db?.close(); } catch {}
+}

--- a/packages/dsh-git-memory/lib/sync-apply.py
+++ b/packages/dsh-git-memory/lib/sync-apply.py
@@ -1287,7 +1287,8 @@ def journal_entry(root_fd, run_id, operation, status, started_at, finished_at,
                   error_code=None, phase=None, staging_digest=None,
                   duration_ms=None, rejected_file_count=0, changed_path_count=None,
                   candidate_digest=None, sync_policy_version=None, update_last_run=True,
-                  error_details=None):
+                  error_details=None, processed_chunk_count=0,
+                  deferred_candidate_count=0, rejected_candidate_count=0):
     record = {
         "schema_version": 1,
         "run_id": run_id,
@@ -1310,6 +1311,9 @@ def journal_entry(root_fd, run_id, operation, status, started_at, finished_at,
         "duration_ms": duration_ms,
         "rejected_file_count": rejected_file_count,
         "changed_path_count": changed_path_count if changed_path_count is not None else len(changed_paths or []),
+        "processed_chunk_count": processed_chunk_count,
+        "deferred_candidate_count": deferred_candidate_count,
+        "rejected_candidate_count": rejected_candidate_count,
     }
     write_journal_file(root_fd, f".sync/runs/{run_id}.json", json.dumps(record, separators=(",", ":")) + "\n", 0o600)
     if update_last_run:
@@ -1318,6 +1322,7 @@ def journal_entry(root_fd, run_id, operation, status, started_at, finished_at,
             "changed_paths", "recovery_commit", "apply_commit", "error_code", "phase",
             "staging_digest", "candidate_digest", "sync_policy_version", "duration_ms",
             "rejected_file_count", "changed_path_count",
+            "processed_chunk_count", "deferred_candidate_count", "rejected_candidate_count",
         )}
         write_journal_file(root_fd, ".sync/last-run.json", json.dumps(last, separators=(",", ":")) + "\n", 0o600)
     return record
@@ -1336,7 +1341,10 @@ def finalize(root, run_id, record, last_sync_ts):
                       record.get("staging_digest"), record.get("duration_ms"),
                       record.get("rejected_file_count", 0), record.get("changed_path_count"),
                       record.get("candidate_digest"), record.get("sync_policy_version"),
-                      error_details=record.get("error_details"))
+                      error_details=record.get("error_details"),
+                      processed_chunk_count=record.get("processed_chunk_count", 0),
+                      deferred_candidate_count=record.get("deferred_candidate_count", 0),
+                      rejected_candidate_count=record.get("rejected_candidate_count", 0))
     finally:
         os.close(root_fd)
     git(root, ["add", "--", ".sync", ".last-sync"])
@@ -1375,6 +1383,9 @@ def main():
     parser.add_argument("--staging-digest", dest="staging_digest")
     parser.add_argument("--duration-ms", dest="duration_ms", type=int)
     parser.add_argument("--rejected-file-count", dest="rejected_file_count", type=int, default=0)
+    parser.add_argument("--processed-chunk-count", dest="processed_chunk_count", type=int, default=0)
+    parser.add_argument("--deferred-candidate-count", dest="deferred_candidate_count", type=int, default=0)
+    parser.add_argument("--rejected-candidate-count", dest="rejected_candidate_count", type=int, default=0)
     parser.add_argument("--candidate-digest", dest="candidate_digest")
     parser.add_argument("--sync-policy-version", dest="sync_policy_version")
     parser.add_argument("--cooldown-seconds", dest="cooldown_seconds", type=int, default=3600)
@@ -1466,7 +1477,10 @@ def main():
                 update_last_run=not args.suppress_last_run,
                 error_details={key: value for key, value in {
                     "id": args.error_id, "first_path": args.first_path, "second_path": args.second_path,
-                }.items() if value is not None})}
+                }.items() if value is not None},
+                processed_chunk_count=args.processed_chunk_count,
+                deferred_candidate_count=args.deferred_candidate_count,
+                rejected_candidate_count=args.rejected_candidate_count)}
         finally:
             os.close(root_fd)
     if args.operation == "finalize":
@@ -1482,6 +1496,9 @@ def main():
                   "staging_digest": args.staging_digest, "candidate_digest": args.candidate_digest,
                   "sync_policy_version": args.sync_policy_version, "duration_ms": args.duration_ms,
                   "rejected_file_count": args.rejected_file_count,
+                  "processed_chunk_count": args.processed_chunk_count,
+                  "deferred_candidate_count": args.deferred_candidate_count,
+                  "rejected_candidate_count": args.rejected_candidate_count,
                   "error_details": {key: value for key, value in {
                       "id": args.error_id, "first_path": args.first_path, "second_path": args.second_path,
                   }.items() if value is not None}}

--- a/packages/dsh-memory-ui/lib/client.js
+++ b/packages/dsh-memory-ui/lib/client.js
@@ -306,6 +306,15 @@ window.__ModuleLoader__.load({
               }
             };
             const unavailable = snapshot.status === "error" ? `长期记忆服务未就绪，暂不能修改（${snapshot.error ?? "settings-unavailable"}）` : snapshot.status === "loading" ? "正在读取长期记忆设置…" : "长期记忆设置不可写";
+            // Metadata anomalies are a data-quality warning surfaced separately
+            // from the repository health line; they never merge into recovery
+            // states on the host side either.
+            const metadataAnomaly = repository?.value && repository.value.metadataValid === false
+              ? {
+                  count: repository.value.invalidMetadataCount ?? 0,
+                  paths: (repository.value.invalidMetadata ?? []).slice(0, 5).map((entry) => entry.path),
+                }
+              : null;
             const repositoryStatus = repository?.error
               ? { tone: "danger", text: `记忆库不可用：${repository.error}`, error: true }
               : repository?.value
@@ -347,6 +356,14 @@ window.__ModuleLoader__.load({
                       jsx.jsx("span", { className: `dshmu_dot dshmu_dot--${repositoryStatus.tone}`, "aria-hidden": "true" }),
                       jsx.jsx("span", { children: repositoryStatus.text }),
                     ] }),
+              ] }) }) }),
+              metadataAnomaly !== null && jsx.jsx("section", { className: "dshmu_row", "aria-label": "记忆数据格式异常", children: jsx.jsx("div", { className: "dshmu_head dshmu_head--static", children: jsx.jsxs("div", { className: "dshmu_headMain", children: [
+                jsx.jsx("div", { className: "dshmu_title", children: "记忆数据格式异常" }),
+                jsx.jsxs("div", { className: "dshmu_statusLine dshmu_statusLine--error", children: [
+                  jsx.jsx("span", { className: "dshmu_dot dshmu_dot--warning", "aria-hidden": "true" }),
+                  jsx.jsx("span", { children: `${metadataAnomaly.count} 条记录的元数据无效；这些记录已从检索中排除，不影响其余记忆的使用与同步` }),
+                ] }),
+                metadataAnomaly.paths.length > 0 && jsx.jsx("span", { className: "dshmu_desc", children: metadataAnomaly.paths.join("、") }),
               ] }) }) }),
               repository !== null && jsx.jsxs("section", { className: "dshmu_row", "aria-label": "最近同步", onKeyDown: rowKeyDown("sync"), children: [
                 lastRun === null

--- a/packages/dsh-memory-ui/package.json
+++ b/packages/dsh-memory-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory-ui",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "private": true,
   "description": "Settings UI for DSH local long-term memory",
   "type": "module",

--- a/packages/dsh-memory-ui/package.json
+++ b/packages/dsh-memory-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory-ui",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "description": "Settings UI for DSH local long-term memory",
   "type": "module",

--- a/packages/dsh-memory-ui/package.json
+++ b/packages/dsh-memory-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory-ui",
-  "version": "0.8.1",
+  "version": "0.8.3",
   "private": true,
   "description": "Settings UI for DSH local long-term memory",
   "type": "module",

--- a/packages/dsh-memory/lib/index.js
+++ b/packages/dsh-memory/lib/index.js
@@ -24,6 +24,13 @@ import { parseFrontMatter, isExpired, topicKey, auditRecords, AUDIT_INVALID_META
 import { legacyId, legacyRecordSummary, migratedContent, scanLegacyRecords } from "./legacy-migration.js";
 import { contentHashOf, formatCitation, readUsage, recordUsage, sortByUsage, usageMetadata } from "./memory-usage.js";
 import { SyncTransaction } from "./sync-transaction.js";
+import {
+  buildSearchIndex,
+  closeSearchIndex,
+  openSearchIndex,
+  querySearchIndex,
+  stampOf,
+} from "./search-index.js";
 
 const execFile = promisify(execFileCallback);
 const NS = settingsNamespace("memory");
@@ -42,6 +49,45 @@ const PYTHON_CANDIDATES = Object.freeze([
   "python3",
 ].filter(Boolean));
 const Config = z.object({ enabled: z.boolean().default(true) });
+
+/**
+ * v0.9.0 hybrid ranking: reciprocal-rank fusion over the raw lexical scan
+ * (weight 2.0), the FTS match rank and token coverage (1.0 each), and the
+ * usage order (0.25). Records containing the full query as an exact
+ * substring form a priority tier above the fused order.
+ */
+function fuseSearchResults(candidates, usage, query) {
+  const usageOrder = sortByUsage(candidates, usage);
+  const rawRank = new Map(candidates.map((entry, index) => [entry.path, index + 1]));
+  const usageRank = new Map(usageOrder.map((entry, index) => [entry.path, index + 1]));
+  const coverageRankEntries = candidates
+    .filter((entry) => (entry.__coverage ?? 0) > 0)
+    .sort((left, right) => (right.__coverage - left.__coverage)
+      || String(left.path).localeCompare(String(right.path)));
+  const coverageRank = new Map(coverageRankEntries.map((entry, index) => [entry.path, index + 1]));
+  const queryLower = String(query).trim().toLowerCase();
+  for (const entry of candidates) {
+    const ftsRank = entry.__ftsRank;
+    const covRank = coverageRank.get(entry.path);
+    const componentRaw = 2.0 / (60 + (rawRank.get(entry.path) ?? candidates.length));
+    const componentFts = ftsRank === undefined ? 0 : 1.0 / (60 + ftsRank);
+    const componentCoverage = covRank === undefined ? 0 : 1.0 / (60 + covRank);
+    const componentUsage = 0.25 / (60 + (usageRank.get(entry.path) ?? candidates.length));
+    entry.score_components = {
+      raw: componentRaw,
+      fts: componentFts,
+      coverage: componentCoverage,
+      usage: componentUsage,
+    };
+    entry.score = componentRaw + componentFts + componentCoverage + componentUsage;
+    entry.__tier = queryLower.length > 0 && typeof entry.__bodyLower === "string"
+      && entry.__bodyLower.includes(queryLower) ? 0 : 1;
+  }
+  return [...candidates].sort((left, right) => left.__tier - right.__tier
+    || right.score - left.score
+    || String(left.path).localeCompare(String(right.path)));
+}
+
 // Single-writer contract: ordinary sessions treat the memory repository as
 // read-only. Persistence happens exclusively through the periodic
 // transactional sync (dsh-memory-sync), which stages model output, verifies
@@ -846,22 +892,26 @@ export class MemoryRepository {
     }
   }
 
-  async collectSearchResults(root, query, includeArchive = false, usage = undefined, warnings = undefined) {
-    const tokens = query.toLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 0);
-    if (tokens.length === 0) throw memoryError("search-invalid-request");
-    const results = [];
+  /**
+   * v0.9.0: one pass over the payload produces the raw lexical ranking AND
+   * the record descriptors the derived index is built from. All eligible
+   * records (including archive) are returned so the index always covers the
+   * full payload; scope filtering happens on the fused candidates. Invalid
+   * metadata is excluded from results but never silently dropped: the caller
+   * returns it as warnings next to the results.
+   */
+  async scanRecords(root, usage) {
+    const records = [];
+    const warnings = [];
     const files = await this.payloadFiles(root);
     for (const file of files) {
       if (file === "summary.md" || !/\.md$/.test(file)) continue;
-      if (!includeArchive && file.startsWith("archive/")) continue;
       const content = await readFileSafe(join(root, file), "utf8").catch(() => "");
       let metadata = null;
       try {
         metadata = parseFrontMatter(content, file);
       } catch (error) {
-        // Invalid metadata is excluded from results but never silently
-        // dropped: the caller returns it as a warning next to the results.
-        warnings?.push({ path: file, code: error instanceof MetadataError ? error.code : "invalid-metadata" });
+        warnings.push({ path: file, code: error instanceof MetadataError ? error.code : "invalid-metadata" });
         continue;
       }
       if (metadata !== null && isExpired(metadata)) continue;
@@ -876,33 +926,148 @@ export class MemoryRepository {
         metadata?.source_hash ?? "",
         body,
       ].join("\n").toLowerCase();
-      let score = 0;
-      for (const token of tokens) {
-        if (searchable.includes(token)) score += 1;
-        if (recordId.toLowerCase().includes(token)) score += 3;
-        if ((metadata?.type ?? "").toLowerCase() === token) score += 2;
-        if (body.toLowerCase().includes(token)) score += 1;
-      }
-      if (score > 0) {
-        const lower = body.toLowerCase();
-        const first = lower.indexOf(tokens[0]);
-        const snippet = first === -1 ? body.slice(0, 160) : body.slice(Math.max(0, first - 40), first + 120).replace(/\s+/g, " ").trim();
-        results.push({
-          path: file,
-          score,
-          id: recordId,
-          type: metadata?.type ?? null,
-          updated_at: metadata?.updated_at ?? null,
-          content_hash: usageInfo.content_hash ?? contentHashOf(content),
-          generation: usageInfo.generation,
-          source_rollouts: metadata?.source_rollouts ?? [],
-          source_session_digest: metadata?.source_session_digest ?? null,
-          snippet,
-          citation: formatCitation(file, recordId),
-        });
-      }
+      const bodyLower = body.toLowerCase();
+      records.push({
+        path: file,
+        id: recordId,
+        type: metadata?.type ?? null,
+        tags: metadata?.tags ?? [],
+        updatedAt: metadata?.updated_at ?? null,
+        rawBody: body,
+        searchable,
+        content_hash: usageInfo.content_hash ?? contentHashOf(content),
+        generation: usageInfo.generation,
+        source_rollouts: metadata?.source_rollouts ?? [],
+        source_session_digest: metadata?.source_session_digest ?? null,
+        citation: formatCitation(file, recordId),
+        __bodyLower: bodyLower,
+        __searchable: searchable,
+      });
     }
-    return results.sort((left, right) => right.score - left.score || String(left.path).localeCompare(String(right.path)));
+    return { records, warnings };
+  }
+
+  /** Raw lexical score of one record against the tokenized query. */
+  rawLexicalScore(record, tokens) {
+    let score = 0;
+    for (const token of tokens) {
+      if (record.__searchable.includes(token)) score += 1;
+      if (record.id.toLowerCase().includes(token)) score += 3;
+      if ((record.type ?? "").toLowerCase() === token) score += 2;
+      if (record.__bodyLower.includes(token)) score += 1;
+    }
+    return score;
+  }
+
+  /** Backwards-compatible raw scan: scored, sorted, archive-filtered. */
+  async collectSearchResults(root, query, includeArchive = false, usage = undefined, warnings = undefined) {
+    const tokens = query.toLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 0);
+    if (tokens.length === 0) throw memoryError("search-invalid-request");
+    const { records, warnings: scanWarnings } = await this.scanRecords(root, usage);
+    const results = [];
+    for (const record of records) {
+      const score = this.rawLexicalScore(record, tokens);
+      if (score <= 0) continue;
+      const first = record.__bodyLower.indexOf(tokens[0]);
+      const snippet = first === -1 ? record.rawBody.slice(0, 160) : record.rawBody.slice(Math.max(0, first - 40), first + 120).replace(/\s+/g, " ").trim();
+      results.push({
+        path: record.path,
+        score,
+        id: record.id,
+        type: record.type,
+        updated_at: record.updatedAt,
+        content_hash: record.content_hash,
+        generation: record.generation,
+        source_rollouts: record.source_rollouts,
+        source_session_digest: record.source_session_digest,
+        snippet,
+        citation: record.citation,
+      });
+    }
+    results.sort((left, right) => right.score - left.score || String(left.path).localeCompare(String(right.path)));
+    if (warnings !== undefined) warnings.push(...(includeArchive ? scanWarnings : scanWarnings.filter((w) => !w.path.startsWith("archive/"))));
+    return includeArchive ? results : results.filter((entry) => !entry.path.startsWith("archive/"));
+  }
+
+  /**
+   * v0.9.0 hybrid retrieval shared by memory_search and memory_context:
+   * raw scan candidates fused with the derived SQLite index signals
+   * (FTS rank + token coverage) and usage order; exact-substring hits form
+   * the top tier. Falls back to the pure scan ranking — marked degraded —
+   * when the index is unavailable.
+   */
+  async retrieve(root, query, scope, usage, warnings) {
+    const inScope = scope === "archive"
+      ? (path) => path.startsWith("archive/")
+      : scope === "active"
+        ? (path) => !path.startsWith("archive/")
+        : () => true;
+    const { records, warnings: scanWarnings } = await this.scanRecords(root, usage);
+    warnings.push(...scanWarnings.filter((warning) => inScope(warning.path)));
+    const candidates = records.filter((record) => inScope(record.path));
+    const tokens = query.toLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 0);
+    if (tokens.length === 0) throw memoryError("search-invalid-request");
+    for (const record of candidates) {
+      const score = this.rawLexicalScore(record, tokens);
+      record.__rawScore = score;
+      const first = record.__bodyLower.indexOf(tokens[0]);
+      record.__snippet = first === -1 ? record.rawBody.slice(0, 160) : record.rawBody.slice(Math.max(0, first - 40), first + 120).replace(/\s+/g, " ").trim();
+    }
+    let retrieval = { mode: "scan", indexState: "degraded", stamp: null };
+    let fts = null;
+    try {
+      const stamp = stampOf(await this.payloadTree("HEAD"));
+      let handle = null;
+      let needsBuild = true;
+      let indexState = "rebuilt";
+      try {
+        handle = await openSearchIndex(root, stamp);
+        if (handle !== null && handle.stampMatches) {
+          needsBuild = false;
+          indexState = "fresh";
+        } else if (handle !== null) {
+          closeSearchIndex(handle);
+          handle = null;
+        }
+      } catch {
+        handle = null;
+      }
+      if (needsBuild) {
+        await buildSearchIndex(root, records, stamp, scanWarnings);
+        handle = await openSearchIndex(root, stamp);
+        if (handle === null) throw new Error("search-index missing after build");
+      }
+      try {
+        fts = querySearchIndex(handle.db, query);
+      } finally {
+        closeSearchIndex(handle);
+      }
+      retrieval = { mode: "hybrid", indexState, stamp };
+    } catch {
+      fts = null;
+      retrieval = { mode: "scan", indexState: "degraded", stamp: null };
+    }
+    for (const record of candidates) {
+      record.__ftsRank = fts?.ranksByPath.get(record.path);
+      record.__coverage = fts?.coverageByPath.get(record.path) ?? 0;
+    }
+    const scored = candidates.filter((record) => record.__rawScore > 0);
+    const ranked = fuseSearchResults(scored, usage, query);
+    const candidates_ = ranked.map((entry) => ({
+      path: entry.path,
+      score: entry.score,
+      id: entry.id,
+      type: entry.type,
+      updated_at: entry.updatedAt,
+      content_hash: entry.content_hash,
+      generation: entry.generation,
+      source_rollouts: entry.source_rollouts,
+      source_session_digest: entry.source_session_digest,
+      snippet: entry.__snippet,
+      citation: entry.citation,
+      score_components: entry.score_components,
+    }));
+    return { candidates: candidates_, recordsForIndex: records, retrieval };
   }
 
   /**
@@ -921,9 +1086,8 @@ export class MemoryRepository {
     try {
       const usage = await readUsage(root);
       const warnings = [];
-      const results = (await this.collectSearchResults(root, request.query, scope !== "active", usage, warnings))
-        .filter((entry) => scope !== "archive" || entry.path.startsWith("archive/"));
-      return success({ query: request.query, count: results.length, results: results.slice(0, limit), warnings });
+      const { candidates, retrieval } = await this.retrieve(root, request.query, scope, usage, warnings);
+      return success({ query: request.query, count: candidates.length, results: candidates.slice(0, limit), warnings, retrieval });
     } catch (error) {
       return failure(error?.memoryCode ?? "search-failed");
     }
@@ -947,8 +1111,11 @@ export class MemoryRepository {
       const usage = await readUsage(root);
       const warnings = [];
       let candidates;
+      let retrieval = null;
       if (hasQuery) {
-        candidates = sortByUsage(await this.collectSearchResults(root, request.query, scope !== "active", usage, warnings), usage).slice(0, limit);
+        const fused = await this.retrieve(root, request.query, scope, usage, warnings);
+        candidates = fused.candidates.slice(0, limit);
+        retrieval = fused.retrieval;
       } else {
         candidates = [];
         for (const file of await this.payloadFiles(root)) {
@@ -1000,7 +1167,7 @@ export class MemoryRepository {
           prior_usage_count: metadata.prior_usage_count,
           source_rollouts: entry.source_rollouts ?? [],
           source_session_digest: entry.source_session_digest ?? null,
-          ...(hasQuery ? { score: entry.score } : {}),
+          ...(hasQuery ? { score: entry.score, score_components: entry.score_components } : {}),
         });
       }
       return success({
@@ -1008,6 +1175,7 @@ export class MemoryRepository {
         count: records.length,
         records,
         warnings,
+        ...(hasQuery ? { retrieval } : {}),
       });
     } catch (error) {
       return failure(error?.memoryCode ?? "context-failed");

--- a/packages/dsh-memory/lib/index.js
+++ b/packages/dsh-memory/lib/index.js
@@ -143,7 +143,7 @@ function startSummaryWatcher(onChange) {
     lastSeen = { mtimeMs: stat.mtimeMs, size: stat.size };
   } catch {}
   let debounceTimer = null;
-  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS }, (current) => {
+  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS, persistent: false }, (current) => {
     // A zeroed stat means the file is temporarily gone; the snapshot
     // retention in buildMemorySectionText covers it, so do not refresh.
     if (!current || (current.size === 0 && current.mtimeMs === 0)) return;

--- a/packages/dsh-memory/lib/index.js
+++ b/packages/dsh-memory/lib/index.js
@@ -1,6 +1,7 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { homedir, tmpdir } from "node:os";
+import { statSync, watchFile, unwatchFile } from "node:fs";
 import { copyFile, lstat, mkdir, mkdtemp, readFile, realpath, rm, rmdir, unlink, writeFile } from "node:fs/promises";
 import { join, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,7 +20,7 @@ import {
   releaseOperationLock,
   writeActiveRun,
 } from "./operation-lock.js";
-import { parseFrontMatter, isExpired, topicKey } from "./memory-metadata.js";
+import { parseFrontMatter, isExpired, topicKey, auditRecords, AUDIT_INVALID_METADATA_LIMIT, MetadataError } from "./memory-metadata.js";
 import { legacyId, legacyRecordSummary, migratedContent, scanLegacyRecords } from "./legacy-migration.js";
 import { contentHashOf, formatCitation, readUsage, recordUsage, sortByUsage, usageMetadata } from "./memory-usage.js";
 import { SyncTransaction } from "./sync-transaction.js";
@@ -41,24 +42,38 @@ const PYTHON_CANDIDATES = Object.freeze([
   "python3",
 ].filter(Boolean));
 const Config = z.object({ enabled: z.boolean().default(true) });
+// Single-writer contract: ordinary sessions treat the memory repository as
+// read-only. Persistence happens exclusively through the periodic
+// transactional sync (dsh-memory-sync), which stages model output, verifies
+// it host-side, and commits it. No session ever runs git or writes to the
+// live repository directly.
 const MEMORY_SECTION = `长期记忆已开启（DPSK 专属仓库 ${DEFAULT_MEMORY_ROOT}，git 版本化；操作手册见 memory 技能）。
 
 自动行为，用户无需提醒：
 1. 每个任务动手前：先读下方 <summary_snapshot>（summary.md 的启动快照），需要细节时用 memory_search / memory_context 工具或 grep handbook/ 检索；命中则遵循，无命中直接开始，不要向用户询问"要不要回忆"。
-2. 完成重要任务或会话收尾时：自动用子代理执行记忆提取（extract → rollouts/）与整合（consolidate → handbook/ 与 summary.md），随后在仓库内 git add -A && git commit。
-3. 用户纠正偏好或告知新约定时：立即更新对应记忆条目。
+2. 普通会话对记忆库只读：不要直接写记忆文件，不要执行任何 git 命令。若本会话产生了值得沉淀的结论，把它作为记忆请求记录在自己的回复或会话中（说明建议归入 handbook/ 或 rollouts/ 的要点）；周期性事务同步（dsh-memory-sync）会在后台完成提取、整合与提交。
+3. 用户纠正偏好或告知新约定时：按第 2 条记录记忆请求；不要当场改写记忆条目。
 
 硬规则：只存证据化结论；禁存凭据（写入 [REDACTED]）；原始会话日志只读；宁缺毋滥。
 `;
 
 export const SUMMARY_BUDGET_BYTES = 12 * 1024;
 const SUMMARY_INJECT_MAX_BYTES = SUMMARY_BUDGET_BYTES;
+// Prompt freshness: the injected summary snapshot must track edits to
+// summary.md without waiting for a settings change. The host polls the file
+// every few seconds; an mtime/size change triggers one debounced async
+// refresh. While the file is briefly missing or unreadable the previous
+// valid snapshot is retained — the prompt is never cleared by a transient
+// read failure.
+let lastSummarySnapshot = null;
 async function buildMemorySectionText() {
   let summary;
   try {
     summary = await readFile(join(DEFAULT_MEMORY_ROOT, "summary.md"), "utf8");
+    lastSummarySnapshot = summary;
   } catch {
-    return MEMORY_SECTION;
+    if (lastSummarySnapshot === null) return MEMORY_SECTION;
+    summary = lastSummarySnapshot;
   }
   const bounded = boundedContextBody(summary, SUMMARY_INJECT_MAX_BYTES);
   const note = bounded.truncated
@@ -69,6 +84,36 @@ async function buildMemorySectionText() {
 <summary_snapshot>
 ${bounded.content}${note}
 </summary_snapshot>`;
+}
+
+const SUMMARY_WATCH_INTERVAL_MS = 5000;
+const SUMMARY_REFRESH_DEBOUNCE_MS = 1000;
+/** Poll summary.md and invoke onChange (debounced) after mtime/size changes. */
+function startSummaryWatcher(onChange) {
+  const summaryPath = join(DEFAULT_MEMORY_ROOT, "summary.md");
+  let lastSeen = null;
+  try {
+    const stat = statSync(summaryPath);
+    lastSeen = { mtimeMs: stat.mtimeMs, size: stat.size };
+  } catch {}
+  let debounceTimer = null;
+  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS }, (current) => {
+    // A zeroed stat means the file is temporarily gone; the snapshot
+    // retention in buildMemorySectionText covers it, so do not refresh.
+    if (!current || (current.size === 0 && current.mtimeMs === 0)) return;
+    if (lastSeen && current.mtimeMs === lastSeen.mtimeMs && current.size === lastSeen.size) return;
+    lastSeen = { mtimeMs: current.mtimeMs, size: current.size };
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      try { onChange(); } catch {}
+    }, SUMMARY_REFRESH_DEBOUNCE_MS);
+  });
+  return () => {
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = null;
+    unwatchFile(summaryPath);
+  };
 }
 
 export const name = "dsh-memory";
@@ -300,6 +345,7 @@ export class MemoryRepository {
       const { dataFileCount } = await safeClear(root, "inspect");
       const targetDirty = (await this.git(["status", "--porcelain", "--", ...TARGETS])).stdout.trim().length > 0;
       const { legacyFileCount, pendingMigration } = await this.metadataStats(root);
+      const audit = await this.metadataAudit(root);
       const lastRun = await this.readLastRun(root);
       const retrySuppressed = await this.readRetrySuppressed(root);
       const summaryBytes = await this.summaryBytes(root);
@@ -314,6 +360,10 @@ export class MemoryRepository {
         schemaVersion: 1,
         legacyFileCount,
         pendingMigration,
+        metadataValid: audit.metadataValid,
+        validMetadataCount: audit.validMetadataCount,
+        invalidMetadataCount: audit.invalidMetadataCount,
+        invalidMetadata: audit.invalidMetadata,
         lastRun,
         retrySuppressed,
         summaryBytes,
@@ -356,6 +406,7 @@ export class MemoryRepository {
       const summaryBytes = await this.summaryBytes(root);
       const failureSentinel = await this.readFailureSentinel(root);
       const finalizeFailure = await this.readFinalizeFailure(root);
+      const audit = await this.metadataAudit(root);
       const interruptedRun = activeState === "interrupted"
         ? activeRun
         : (await this.readLastRun(root))?.status === "interrupted" ? await this.readLastRun(root) : null;
@@ -371,6 +422,10 @@ export class MemoryRepository {
         finalizeFailure,
         retrySuppressed,
         payloadDirty,
+        metadataValid: audit.metadataValid,
+        validMetadataCount: audit.validMetadataCount,
+        invalidMetadataCount: audit.invalidMetadataCount,
+        invalidMetadata: audit.invalidMetadata,
         operationLock: operationLock === null ? null : {
           operation: operationLock.operation ?? null,
           pid: operationLock.pid ?? null,
@@ -383,6 +438,8 @@ export class MemoryRepository {
         pendingPreview: previews[0] ?? null,
         pendingPreviewCount: previews.length,
         journalReadable,
+        // Metadata anomalies are a data-quality warning, not a recovery
+        // blocker: reads and the periodic sync keep working around them.
         needsManualRecovery: payloadDirty || activeState === "interrupted" || interruptedRun !== null || !journalReadable
           || summaryBytes > SUMMARY_BUDGET_BYTES || (failureSentinel?.consecutive_failures ?? 0) >= 3
           || finalizeFailure !== null,
@@ -404,6 +461,27 @@ export class MemoryRepository {
     } catch {
       return { legacyFileCount: 0, pendingMigration: false };
     }
+  }
+
+  /** Record-shaped payload files eligible for the metadata audit. */
+  async recordFiles(root) {
+    return (await this.payloadFiles(root)).filter((file) => file !== "summary.md" && /\.md$/.test(file));
+  }
+
+  /**
+   * Shared metadata audit (report-only). Structured records are validated
+   * against schema v1; duplicate ids and unreadable files are reported.
+   * Metadata anomalies never block reads here and are deliberately not part
+   * of needsManualRecovery — the UI surfaces them as a separate warning.
+   */
+  async metadataAudit(root) {
+    const files = await this.recordFiles(root);
+    const records = [];
+    for (const file of files) {
+      const content = await readFileSafe(join(root, file), "utf8").catch(() => null);
+      records.push({ path: file, content });
+    }
+    return auditRecords(records);
   }
 
   async summaryBytes(root) {
@@ -768,7 +846,7 @@ export class MemoryRepository {
     }
   }
 
-  async collectSearchResults(root, query, includeArchive = false, usage = undefined) {
+  async collectSearchResults(root, query, includeArchive = false, usage = undefined, warnings = undefined) {
     const tokens = query.toLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 0);
     if (tokens.length === 0) throw memoryError("search-invalid-request");
     const results = [];
@@ -778,7 +856,14 @@ export class MemoryRepository {
       if (!includeArchive && file.startsWith("archive/")) continue;
       const content = await readFileSafe(join(root, file), "utf8").catch(() => "");
       let metadata = null;
-      try { metadata = parseFrontMatter(content, file); } catch { continue; }
+      try {
+        metadata = parseFrontMatter(content, file);
+      } catch (error) {
+        // Invalid metadata is excluded from results but never silently
+        // dropped: the caller returns it as a warning next to the results.
+        warnings?.push({ path: file, code: error instanceof MetadataError ? error.code : "invalid-metadata" });
+        continue;
+      }
       if (metadata !== null && isExpired(metadata)) continue;
       const recordId = metadata?.id ?? legacyId(file);
       const usageInfo = usageMetadata(file, usage);
@@ -835,9 +920,10 @@ export class MemoryRepository {
     try { root = await this.inspect(); } catch (error) { return failure(error?.memoryCode ?? "repo-unavailable"); }
     try {
       const usage = await readUsage(root);
-      const results = (await this.collectSearchResults(root, request.query, scope !== "active", usage))
+      const warnings = [];
+      const results = (await this.collectSearchResults(root, request.query, scope !== "active", usage, warnings))
         .filter((entry) => scope !== "archive" || entry.path.startsWith("archive/"));
-      return success({ query: request.query, count: results.length, results: results.slice(0, limit) });
+      return success({ query: request.query, count: results.length, results: results.slice(0, limit), warnings });
     } catch (error) {
       return failure(error?.memoryCode ?? "search-failed");
     }
@@ -859,9 +945,10 @@ export class MemoryRepository {
     try { root = await this.inspect(); } catch (error) { return failure(error?.memoryCode ?? "repo-unavailable"); }
     try {
       const usage = await readUsage(root);
+      const warnings = [];
       let candidates;
       if (hasQuery) {
-        candidates = sortByUsage(await this.collectSearchResults(root, request.query, scope !== "active", usage), usage).slice(0, limit);
+        candidates = sortByUsage(await this.collectSearchResults(root, request.query, scope !== "active", usage, warnings), usage).slice(0, limit);
       } else {
         candidates = [];
         for (const file of await this.payloadFiles(root)) {
@@ -870,7 +957,12 @@ export class MemoryRepository {
           if (scope === "archive" && !file.startsWith("archive/")) continue;
           const content = await readFileSafe(join(root, file), "utf8").catch(() => "");
           let metadata = null;
-          try { metadata = parseFrontMatter(content, file); } catch { continue; }
+          try {
+            metadata = parseFrontMatter(content, file);
+          } catch (error) {
+            warnings?.push({ path: file, code: error instanceof MetadataError ? error.code : "invalid-metadata" });
+            continue;
+          }
           if (metadata !== null && isExpired(metadata)) continue;
           const recordId = metadata?.id ?? legacyId(file);
           candidates.push({
@@ -915,6 +1007,7 @@ export class MemoryRepository {
         query: hasQuery ? request.query : null,
         count: records.length,
         records,
+        warnings,
       });
     } catch (error) {
       return failure(error?.memoryCode ?? "context-failed");
@@ -1220,6 +1313,11 @@ export function apply(ctx, entry) {
     };
     refreshPrompt = refresh;
     refresh();
-    promptCtx.effect(() => () => { if (refreshPrompt === refresh) refreshPrompt = () => {}; disposeSection?.(); }, "dsh-memory: section cleanup");
+    const stopSummaryWatcher = startSummaryWatcher(refresh);
+    promptCtx.effect(() => () => {
+      stopSummaryWatcher();
+      if (refreshPrompt === refresh) refreshPrompt = () => {};
+      disposeSection?.();
+    }, "dsh-memory: section cleanup");
   });
 }

--- a/packages/dsh-memory/lib/memory-metadata.js
+++ b/packages/dsh-memory/lib/memory-metadata.js
@@ -105,6 +105,12 @@ function parseBlock(block) {
     const key = line.slice(0, colon).trim();
     const value = line.slice(colon + 1).trim();
     if (key === "") throw new MetadataError("invalid-metadata", "front matter has an empty key");
+    // Canonical records use block lists (tags:\n  - item). Flow-style
+    // collections are rejected with a stable code so the staging validator and
+    // the metadata audit report the same, actionable diagnosis.
+    if ((value.startsWith("[") && value !== "[]") || (value.startsWith("{") && value !== "{}")) {
+      throw new MetadataError("flow-style-metadata", `${key} must use a canonical block list, not a flow collection`);
+    }
     currentKey = key;
     if (value === "" || value.startsWith("|") || value.startsWith(">")) {
       // A nested mapping or block scalar is not part of the record contract.
@@ -277,4 +283,77 @@ export function resolveTopicConflict(records, now = Date.now()) {
     if (dateDiff !== 0) return dateDiff;
     return String(left.id).localeCompare(String(right.id));
   })[0];
+}
+
+export const AUDIT_INVALID_METADATA_LIMIT = 20;
+
+/**
+ * Shared metadata audit over structured records (schema_version 1).
+ *
+ * Scans every record-shaped payload document and reports:
+ *   - per-file validation failures (schema, fields, duplicate ids);
+ *   - legacy records (no front matter) which are counted but never invalid;
+ *   - duplicate structured ids across the corpus.
+ *
+ * The audit is report-only: callers decide whether invalid metadata blocks a
+ * write path (staging validation stays fail-closed) or only surfaces in
+ * status/health and search warnings. Legacy records grandfather as valid.
+ *
+ * @param {Array<{ path: string, content: string }>} records
+ * @returns {{ metadataValid: boolean, validMetadataCount: number, invalidMetadataCount: number, legacyMetadataCount: number, duplicateIdCount: number, invalidMetadata: Array<{ path: string, code: string }> }}
+ */
+export function auditRecords(records) {
+  let validCount = 0;
+  let legacyCount = 0;
+  const invalid = [];
+  let invalidCount = 0;
+  const seenIds = new Map();
+  let duplicateIdCount = 0;
+  for (const record of records) {
+    if (record.content === null || record.content === undefined) {
+      // The file could not be read at all; that is an invalid record, not a
+      // legacy one, so it surfaces in the audit instead of disappearing.
+      invalidCount += 1;
+      if (invalid.length < AUDIT_INVALID_METADATA_LIMIT) invalid.push({ path: record.path, code: "unreadable" });
+      continue;
+    }
+    if (!hasRecordFrontMatter(record.content)) {
+      legacyCount += 1;
+      continue;
+    }
+    try {
+      const metadata = parseFrontMatter(record.content, record.path);
+      if (metadata === null) {
+        // Not a record path (defensive; callers pre-filter).
+        continue;
+      }
+      validCount += 1;
+      const first = seenIds.get(metadata.id);
+      if (first !== undefined) {
+        duplicateIdCount += 1;
+        invalidCount += 1;
+        if (invalid.length < AUDIT_INVALID_METADATA_LIMIT) {
+          invalid.push({ path: record.path, code: "duplicate-id" });
+        }
+      } else {
+        seenIds.set(metadata.id, record.path);
+      }
+    } catch (error) {
+      const code = error instanceof MetadataError ? error.code : "invalid-metadata";
+      invalidCount += 1;
+      if (invalid.length < AUDIT_INVALID_METADATA_LIMIT) invalid.push({ path: record.path, code });
+    }
+  }
+  return {
+    metadataValid: invalidCount === 0,
+    validMetadataCount: validCount,
+    invalidMetadataCount: invalidCount,
+    legacyMetadataCount: legacyCount,
+    duplicateIdCount,
+    invalidMetadata: invalid,
+  };
+}
+
+function hasRecordFrontMatter(content) {
+  return content.startsWith("---\n") || content.startsWith("---\r\n");
 }

--- a/packages/dsh-memory/lib/search-index.js
+++ b/packages/dsh-memory/lib/search-index.js
@@ -1,0 +1,241 @@
+// v0.9.0 derived SQLite search index.
+//
+// The index is a cache derived from the payload tree at HEAD; its validity
+// stamp is sha256(payloadTree(HEAD)) so every applied sync commit (which
+// changes HEAD) invalidates it. The database lives at .sync/search-index.sqlite
+// (mode 0600, git-excluded), is built into a temporary file and atomically
+// renamed into place, and is opened read-only on the query path. When SQLite
+// or FTS5 is unavailable, or the index cannot be built or read, callers fall
+// back to the full scan with retrieval.mode = "scan" and indexState =
+// "degraded"; search results stay correct, only the ranking components shrink.
+import { createHash, randomUUID } from "node:crypto";
+import { chmod, lstat, rename, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+export const SEARCH_INDEX_SCHEMA_VERSION = 1;
+export const SEARCH_INDEX_FILE = ".sync/search-index.sqlite";
+export const SEARCH_INDEX_TEMP_PREFIX = ".search-index.";
+export const SEARCH_INDEX_TEMP_SUFFIX = ".tmp";
+export const RRF_K = 60;
+export const RRF_WEIGHTS = Object.freeze({ raw: 2.0, fts: 1.0, coverage: 1.0, usage: 0.25 });
+
+const CJK_RUN = /[\u3400-\u4dbf\u4e00-\u9fff]+/g;
+const LATIN_WORD = /[a-z0-9_][a-z0-9_-]*/g;
+
+let sqlitePromise = null;
+
+async function loadSqlite() {
+  if (sqlitePromise === null) {
+    sqlitePromise = import("node:sqlite").then((module) => module.DatabaseSync);
+  }
+  return await sqlitePromise;
+}
+
+export async function isSqliteAvailable() {
+  try {
+    await loadSqlite();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** sha256 over "blob-object path" lines of the payload tree at a commit. */
+export function stampOf(payloadTreeText) {
+  return `sha256:${createHash("sha256").update(payloadTreeText, "utf8").digest("hex")}`;
+}
+
+/**
+ * Derived index terms for one record: lowercase latin words plus CJK
+ * character bigrams (a lone CJK character is kept as a unigram). The query
+ * side reuses this function so index and query token spaces always match.
+ */
+export function derivedTerms(text) {
+  const tokens = [];
+  const lower = String(text).toLowerCase();
+  for (const word of lower.match(LATIN_WORD) ?? []) tokens.push(word);
+  for (const run of String(text).match(CJK_RUN) ?? []) {
+    if (run.length === 1) {
+      tokens.push(run);
+      continue;
+    }
+    for (let index = 0; index < run.length - 1; index += 1) tokens.push(run.slice(index, index + 2));
+  }
+  return tokens.join(" ");
+}
+
+/** Split a query into the FTS signals the index can answer. */
+export function tokenizeQuery(query) {
+  const trimmed = String(query).trim();
+  const words = new Set();
+  const bigrams = new Set();
+  const phrases = [];
+  const lower = trimmed.toLowerCase();
+  for (const word of lower.match(LATIN_WORD) ?? []) {
+    if (word.length >= 2) words.add(word);
+    if (word.length >= 3) phrases.push(word);
+  }
+  for (const run of trimmed.match(CJK_RUN) ?? []) {
+    if (run.length >= 3) phrases.push(run);
+    if (run.length === 1) {
+      bigrams.add(run);
+      continue;
+    }
+    for (let index = 0; index < run.length - 1; index += 1) bigrams.add(run.slice(index, index + 2));
+  }
+  if ([...trimmed].length >= 3) phrases.push(trimmed);
+  return { words: [...words], bigrams: [...bigrams], phrases };
+}
+
+function ftsMatchOr(terms) {
+  return terms.map((term) => `"${term.replaceAll('"', '""')}"`).join(" OR ");
+}
+
+function ftsMatchPlain(terms) {
+  return terms.join(" OR ");
+}
+
+async function ensureIndexGitExcludes(root) {
+  const excludePath = join(root, ".git", "info", "exclude");
+  const current = await (await import("node:fs/promises")).readFile(excludePath, "utf8").catch(() => "");
+  const lines = current.split(/\r?\n/);
+  const wanted = [".sync/search-index.sqlite", `.sync/${SEARCH_INDEX_TEMP_PREFIX}*${SEARCH_INDEX_TEMP_SUFFIX}`];
+  const missing = wanted.filter((entry) => !lines.includes(entry));
+  if (missing.length === 0) return;
+  const suffix = current.length === 0 || current.endsWith("\n") ? "" : "\n";
+  const { writeFile } = await import("node:fs/promises");
+  await writeFile(excludePath, `${current}${suffix}${missing.join("\n")}\n`, { mode: 0o600 });
+  await chmod(excludePath, 0o600).catch(() => {});
+}
+
+/**
+ * Build the index from eligible records and atomically replace the previous
+ * database. `records` items: {path, id, type, tags, updatedAt, rawBody,
+ * searchable} — `searchable` is the raw-scan scoring text, `rawBody` the
+ * front-matter-free body used for snippets and exact-substring tiers.
+ */
+export async function buildSearchIndex(root, records, stamp, warnings = []) {
+  const DatabaseSync = await loadSqlite();
+  const syncRoot = join(root, ".sync");
+  const finalPath = join(syncRoot, "search-index.sqlite");
+  const temporary = join(syncRoot, `${SEARCH_INDEX_TEMP_PREFIX}${process.pid}.${randomUUID()}${SEARCH_INDEX_TEMP_SUFFIX}`);
+  let db;
+  try {
+    db = new DatabaseSync(temporary);
+    db.exec("PRAGMA journal_mode=DELETE;");
+    db.exec(`
+      CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+      CREATE TABLE records(
+        path TEXT PRIMARY KEY,
+        id TEXT,
+        type TEXT,
+        tags TEXT,
+        updated_at TEXT,
+        raw_body TEXT,
+        searchable TEXT
+      );
+      CREATE VIRTUAL TABLE content_fts USING fts5(path UNINDEXED, body, tokenize='trigram');
+      CREATE VIRTUAL TABLE terms_fts USING fts5(path UNINDEXED, terms, tokenize='unicode61');
+      CREATE TABLE invalid_metadata(path TEXT PRIMARY KEY, code TEXT NOT NULL);
+    `);
+    const insertRecord = db.prepare(
+      "INSERT INTO records(path, id, type, tags, updated_at, raw_body, searchable) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    );
+    const insertContent = db.prepare("INSERT INTO content_fts(path, body) VALUES (?, ?)");
+    const insertTerms = db.prepare("INSERT INTO terms_fts(path, terms) VALUES (?, ?)");
+    const insertWarning = db.prepare("INSERT INTO invalid_metadata(path, code) VALUES (?, ?)");
+    db.exec("BEGIN");
+    for (const record of records) {
+      const tags = JSON.stringify(record.tags ?? []);
+      insertRecord.run(record.path, record.id, record.type, tags, record.updatedAt, record.rawBody, record.searchable);
+      insertContent.run(record.path, record.searchable);
+      insertTerms.run(record.path, derivedTerms(record.searchable));
+    }
+    for (const warning of warnings) insertWarning.run(warning.path, warning.code);
+    db.exec("COMMIT");
+    db.exec(`
+      INSERT INTO meta(key, value) VALUES ('schema_version', '${SEARCH_INDEX_SCHEMA_VERSION}');
+      INSERT INTO meta(key, value) VALUES ('stamp', '${stamp.replaceAll("'", "''")}');
+      INSERT INTO meta(key, value) VALUES ('built_at', '${new Date().toISOString()}');
+    `);
+    db.close();
+    db = undefined;
+    await chmod(temporary, 0o600);
+    await rename(temporary, finalPath);
+    await chmod(finalPath, 0o600).catch(() => {});
+    await ensureIndexGitExcludes(root).catch(() => {});
+  } catch (error) {
+    try { db?.close(); } catch {}
+    await rm(temporary, { force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+/**
+ * Open the index read-only. Returns:
+ *   { db, stampMatches }         — database opened
+ *   null                         — no index file present
+ * and throws on a corrupt or schema-mismatched database (caller rebuilds).
+ */
+export async function openSearchIndex(root, expectedStamp) {
+  const path = join(root, SEARCH_INDEX_FILE);
+  const stat = await lstat(path).catch((error) => {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  });
+  if (stat === null) return null;
+  if (stat.isSymbolicLink() || !stat.isFile()) throw new Error("search-index: unsafe layout");
+  const DatabaseSync = await loadSqlite();
+  const db = new DatabaseSync(path, { readOnly: true });
+  try {
+    const schemaVersion = db.prepare("SELECT value FROM meta WHERE key = 'schema_version'").get()?.value;
+    if (Number(schemaVersion) !== SEARCH_INDEX_SCHEMA_VERSION) throw new Error("search-index: schema mismatch");
+    const stamp = db.prepare("SELECT value FROM meta WHERE key = 'stamp'").get()?.value ?? "";
+    return { db, stampMatches: stamp === expectedStamp };
+  } catch (error) {
+    try { db.close(); } catch {}
+    throw error;
+  }
+}
+
+/**
+ * Query the index. Returns { ranksByPath, coverageByPath, stamp } where
+ * ranksByPath is a 1-based best-effort FTS rank (trigram matches first, then
+ * term matches) and coverageByPath maps paths to the fraction of query tokens
+ * matched. Returns null when the query produces no usable FTS signals.
+ */
+export function querySearchIndex(db, query) {
+  const { words, bigrams, phrases } = tokenizeQuery(query);
+  const ranksByPath = new Map();
+  const coverageTokens = new Map();
+  const totalTokens = words.length + bigrams.length;
+  const consider = (list) => {
+    for (const path of list) if (!ranksByPath.has(path)) ranksByPath.set(path, ranksByPath.size + 1);
+  };
+  if (phrases.length > 0) {
+    const rows = db.prepare("SELECT path, bm25(content_fts) AS r FROM content_fts WHERE content_fts MATCH ? ORDER BY r").all(ftsMatchOr(phrases));
+    consider(rows.map((row) => row.path));
+  }
+  if (words.length > 0 || bigrams.length > 0) {
+    const termTokens = [...words, ...bigrams];
+    for (const token of termTokens) {
+      const rows = db.prepare("SELECT path FROM terms_fts WHERE terms_fts MATCH ?").all(ftsMatchPlain([token]));
+      for (const row of rows) {
+        if (!coverageTokens.has(row.path)) coverageTokens.set(row.path, new Set());
+        coverageTokens.get(row.path).add(token);
+      }
+    }
+    const rows = db.prepare("SELECT path, bm25(terms_fts) AS r FROM terms_fts WHERE terms_fts MATCH ? ORDER BY r").all(ftsMatchPlain(termTokens));
+    consider(rows.map((row) => row.path));
+  }
+  const coverageByPath = new Map();
+  for (const [path, matched] of coverageTokens) {
+    coverageByPath.set(path, totalTokens === 0 ? 0 : matched.size / totalTokens);
+  }
+  return { ranksByPath, coverageByPath };
+}
+
+/** Close a handle returned by openSearchIndex. */
+export function closeSearchIndex(handle) {
+  try { handle?.db?.close(); } catch {}
+}

--- a/packages/dsh-memory/lib/sync-apply.py
+++ b/packages/dsh-memory/lib/sync-apply.py
@@ -1287,7 +1287,8 @@ def journal_entry(root_fd, run_id, operation, status, started_at, finished_at,
                   error_code=None, phase=None, staging_digest=None,
                   duration_ms=None, rejected_file_count=0, changed_path_count=None,
                   candidate_digest=None, sync_policy_version=None, update_last_run=True,
-                  error_details=None):
+                  error_details=None, processed_chunk_count=0,
+                  deferred_candidate_count=0, rejected_candidate_count=0):
     record = {
         "schema_version": 1,
         "run_id": run_id,
@@ -1310,6 +1311,9 @@ def journal_entry(root_fd, run_id, operation, status, started_at, finished_at,
         "duration_ms": duration_ms,
         "rejected_file_count": rejected_file_count,
         "changed_path_count": changed_path_count if changed_path_count is not None else len(changed_paths or []),
+        "processed_chunk_count": processed_chunk_count,
+        "deferred_candidate_count": deferred_candidate_count,
+        "rejected_candidate_count": rejected_candidate_count,
     }
     write_journal_file(root_fd, f".sync/runs/{run_id}.json", json.dumps(record, separators=(",", ":")) + "\n", 0o600)
     if update_last_run:
@@ -1318,6 +1322,7 @@ def journal_entry(root_fd, run_id, operation, status, started_at, finished_at,
             "changed_paths", "recovery_commit", "apply_commit", "error_code", "phase",
             "staging_digest", "candidate_digest", "sync_policy_version", "duration_ms",
             "rejected_file_count", "changed_path_count",
+            "processed_chunk_count", "deferred_candidate_count", "rejected_candidate_count",
         )}
         write_journal_file(root_fd, ".sync/last-run.json", json.dumps(last, separators=(",", ":")) + "\n", 0o600)
     return record
@@ -1336,7 +1341,10 @@ def finalize(root, run_id, record, last_sync_ts):
                       record.get("staging_digest"), record.get("duration_ms"),
                       record.get("rejected_file_count", 0), record.get("changed_path_count"),
                       record.get("candidate_digest"), record.get("sync_policy_version"),
-                      error_details=record.get("error_details"))
+                      error_details=record.get("error_details"),
+                      processed_chunk_count=record.get("processed_chunk_count", 0),
+                      deferred_candidate_count=record.get("deferred_candidate_count", 0),
+                      rejected_candidate_count=record.get("rejected_candidate_count", 0))
     finally:
         os.close(root_fd)
     git(root, ["add", "--", ".sync", ".last-sync"])
@@ -1375,6 +1383,9 @@ def main():
     parser.add_argument("--staging-digest", dest="staging_digest")
     parser.add_argument("--duration-ms", dest="duration_ms", type=int)
     parser.add_argument("--rejected-file-count", dest="rejected_file_count", type=int, default=0)
+    parser.add_argument("--processed-chunk-count", dest="processed_chunk_count", type=int, default=0)
+    parser.add_argument("--deferred-candidate-count", dest="deferred_candidate_count", type=int, default=0)
+    parser.add_argument("--rejected-candidate-count", dest="rejected_candidate_count", type=int, default=0)
     parser.add_argument("--candidate-digest", dest="candidate_digest")
     parser.add_argument("--sync-policy-version", dest="sync_policy_version")
     parser.add_argument("--cooldown-seconds", dest="cooldown_seconds", type=int, default=3600)
@@ -1466,7 +1477,10 @@ def main():
                 update_last_run=not args.suppress_last_run,
                 error_details={key: value for key, value in {
                     "id": args.error_id, "first_path": args.first_path, "second_path": args.second_path,
-                }.items() if value is not None})}
+                }.items() if value is not None},
+                processed_chunk_count=args.processed_chunk_count,
+                deferred_candidate_count=args.deferred_candidate_count,
+                rejected_candidate_count=args.rejected_candidate_count)}
         finally:
             os.close(root_fd)
     if args.operation == "finalize":
@@ -1482,6 +1496,9 @@ def main():
                   "staging_digest": args.staging_digest, "candidate_digest": args.candidate_digest,
                   "sync_policy_version": args.sync_policy_version, "duration_ms": args.duration_ms,
                   "rejected_file_count": args.rejected_file_count,
+                  "processed_chunk_count": args.processed_chunk_count,
+                  "deferred_candidate_count": args.deferred_candidate_count,
+                  "rejected_candidate_count": args.rejected_candidate_count,
                   "error_details": {key: value for key, value in {
                       "id": args.error_id, "first_path": args.first_path, "second_path": args.second_path,
                   }.items() if value is not None}}

--- a/packages/dsh-memory/package.json
+++ b/packages/dsh-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "private": true,
   "description": "Automatic local long-term memory for DSH",
   "type": "module",

--- a/packages/dsh-memory/package.json
+++ b/packages/dsh-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "description": "Automatic local long-term memory for DSH",
   "type": "module",

--- a/packages/dsh-memory/package.json
+++ b/packages/dsh-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "description": "Automatic local long-term memory for DSH",
   "type": "module",

--- a/packages/dsh-memory/templates/README.md
+++ b/packages/dsh-memory/templates/README.md
@@ -31,8 +31,35 @@
 
 原始会话日志仍保留在本地 DSH 会话目录中，过滤器不会改写或删除源日志。若敏感值已经进入记忆 Git 历史，普通回退或删除当前文件不能保证彻底抹除；停止同步、轮换相关凭据，并按本机数据保留策略处理源日志和仓库历史。
 
+## 写入边界（单写者契约）
+
+普通会话对本仓库**只读**：不要直接写任何记忆文件，不要执行任何 git 命令。唯一写入路径是周期性事务同步 `dsh-memory-sync`：模型只在宿主准备的隔离 staging 副本中修改 `summary.md`、`handbook/`、`rollouts/`、`archive/`，退出后由宿主校验、提交并推进水位；本仓库的 README、`.sync/.gitignore` 和 `scripts/filter_session.py` 是宿主管理的只读模板，模型与 staging 都不得修改。
+
+会话中产生的记忆请求（建议沉淀的结论）记录在会话输出中即可，由后续同步负责落库。
+
+## 元数据规范
+
+新增或修改 handbook/ 与 rollouts/ 记录时必须携带 schema v1 front matter；列表字段（如 `tags`、`source_rollouts`）必须使用块列表，不允许行内流程写法：
+
+```yaml
+---
+schema_version: 1
+id: preference-response-language
+type: preference
+status: active
+confidence: high
+created_at: 2026-08-19
+updated_at: 2026-08-19
+tags:
+  - dsh-memory
+  - 检索
+source_rollouts:
+  - rollouts/2026-08-19-session-001.md
+---
+```
+
 ## 提炼与整合
 
 提炼时只保留：稳定用户偏好、最终方案与原因、失败模式、项目入口、可复现命令和明确的后续契约。无高信号时写 `NO_SIGNAL` 并跳过。
 
-整合时先比较新旧条目：冲突则覆盖、过时则移入 `archive/`、无变化则不制造噪声。`summary.md` 最终必须不超过 12 KiB；超出时压缩重复过程和细节，不得静默超出预算。完成后提交本仓库中的实际变更。
+整合时先比较新旧条目：冲突则覆盖、过时则移入 `archive/`、无变化则不制造噪声。`summary.md` 最终必须不超过 12 KiB；超出时压缩重复过程和细节，不得静默超出预算。不要执行 git、不要更新同步水位：宿主会在 staging 校验通过后代为提交。

--- a/packages/dsh-memory/templates/scripts/filter_session.py
+++ b/packages/dsh-memory/templates/scripts/filter_session.py
@@ -4,6 +4,21 @@
 Usage:
   python3 filter_session.py <session.jsonl.zstd> [> transcript.md]
   zstd -dc <session.jsonl.zstd> | python3 filter_session.py -
+
+Chunked mode (v0.8.4): the transcript is written as fixed-size sanitized
+chunks with a provenance header, so the host can stream large sessions to
+the model without ever materializing the raw payload:
+
+  python3 filter_session.py <session.jsonl.zstd> \
+    --chunk-dir <dir> --chunk-bytes 1048576 \
+    --session-digest <sha256> [--max-decompressed-bytes 134217728]
+
+Chunked mode prints one JSON summary line on stdout:
+  {"session_id": "...", "chunk_total": N, "transcript_bytes": B}
+
+The decoder is streaming: the decompressed payload is consumed line by line
+and never fully materialized in memory; a session whose decompressed stream
+exceeds --max-decompressed-bytes fails closed with `decompressed-too-large`.
 """
 import json
 import os
@@ -11,6 +26,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 
 ARG_MAX = 200
 RESULT_MAX = 400
@@ -19,6 +35,7 @@ METADATA_MAX = 400
 REDACTION = "[REDACTED]"
 ZSTD_MAGIC = b"\x28\xb5\x2f\xfd"
 ZSTD_FALLBACKS = ("/opt/homebrew/bin/zstd", "/usr/local/bin/zstd")
+DEFAULT_MAX_DECOMPRESSED_BYTES = 128 * 1024 * 1024
 
 BEARER_RE = re.compile(r"(?i)\bbearer[ \t]+[A-Za-z0-9._~+/=-]{3,}")
 SK_KEY_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{3,}", re.IGNORECASE)
@@ -36,6 +53,14 @@ HOME_PREFIX_RE = re.compile(r"(?<![A-Za-z0-9_])(?:/Users/[^/\s]+|/home/[^/\s]+|/
 SENSITIVE_FIELD_RE = re.compile(
     r"(?i)^(?:access[_-]?token|api[_-]?key|authorization|auth|password|passwd|pwd|secret|token)$"
 )
+
+
+class FilterFailure(RuntimeError):
+    """A fail-closed filter error with a stable single-line code."""
+
+    def __init__(self, code, message):
+        super().__init__(message)
+        self.code = code
 
 
 def redact_text(value: str) -> str:
@@ -115,55 +140,72 @@ def safe_metadata(value) -> str:
     return truncate(redact_text(str(value)), METADATA_MAX)
 
 
-def render(events):
-    out = []
-    header = next(
-        (event for event in events if isinstance(event, dict) and event.get("type") == "session"),
-        {},
-    )
-    title = None
-    for event in events:
-        if not isinstance(event, dict) or event.get("type") != "session/title":
-            continue
-        data = event.get("data", {})
-        if isinstance(data, dict):
-            message = data.get("message", {})
-            title = data.get("title") or (message.get("title") if isinstance(message, dict) else None)
-    out.append(f"# Session {safe_metadata(header.get('id', '?'))}")
-    out.append(f"- cwd: {safe_metadata(header.get('cwd', '?'))}")
-    out.append(f"- preset: {safe_metadata(header.get('agentPreset', '?'))}")
-    if title:
-        out.append(f"- title: {safe_metadata(title)}")
-    out.append("")
+class StreamingRenderer:
+    """Incremental transcript renderer: bounded memory, single decode pass.
 
-    turn = None
-    for event in events:
+    The session header block is emitted when the `session` event appears
+    (first line in DSH logs); title and per-turn sections stream out as the
+    matching events arrive.
+    """
+
+    def __init__(self):
+        self.lines = []
+        self.header_done = False
+        self.session_id = None
+        self.title_done = False
+        self.turn = None
+
+    def _header(self, header):
+        self.lines.append(f"# Session {safe_metadata(header.get('id', '?'))}")
+        self.lines.append(f"- cwd: {safe_metadata(header.get('cwd', '?'))}")
+        self.lines.append(f"- preset: {safe_metadata(header.get('agentPreset', '?'))}")
+        self.lines.append("")
+
+    def feed(self, event):
         if not isinstance(event, dict):
-            continue
+            return
         event_type = event.get("type")
         data = event.get("data", {}) if isinstance(event.get("data"), dict) else {}
-        if event_type == "turn/start":
-            turn = data.get("turn")
+        if event_type == "session":
+            self.session_id = str(event.get("id") or data.get("id") or "?")
+            self._header(event if event.get("id") is not None else data)
+            self.header_done = True
+        elif event_type == "session/title":
+            if self.title_done:
+                return
+            message = data.get("message", {})
+            title = data.get("title") or (message.get("title") if isinstance(message, dict) else None)
+            if title:
+                if not self.header_done:
+                    self._header({})
+                    self.header_done = True
+                self.lines.insert(3, f"- title: {safe_metadata(title)}")
+                self.title_done = True
+        elif event_type == "turn/start":
+            self.turn = data.get("turn")
         elif event_type == "user/message":
             texts = text_blocks(data)
             if texts:
-                out.extend([f"## Turn {turn or '?'} · user", truncate("\n".join(texts), MESSAGE_MAX), ""])
+                self.lines.extend([
+                    f"## Turn {self.turn or '?'} · user",
+                    truncate("\n".join(texts), MESSAGE_MAX),
+                    "",
+                ])
         elif event_type == "assistant/message":
             texts = text_blocks(data.get("message", {}))
             if texts:
-                out.extend([f"## Turn {turn or '?'} · assistant", truncate("\n".join(texts), MESSAGE_MAX), ""])
+                self.lines.extend([
+                    f"## Turn {self.turn or '?'} · assistant",
+                    truncate("\n".join(texts), MESSAGE_MAX),
+                    "",
+                ])
         elif event_type == "tool/call":
             name = safe_metadata(data.get("name", "?"))
-            out.append(f"- tool: {name}({summarize_arguments(data.get('arguments', ''))})")
+            self.lines.append(f"- tool: {name}({summarize_arguments(data.get('arguments', ''))})")
         elif event_type == "tool/result":
             results = list(result_texts(data.get("message", {})))
             if results:
-                out.append(f"- result: {truncate(' '.join(results), RESULT_MAX)}")
-    return "\n".join(out)
-
-
-class ZstdUnavailable(RuntimeError):
-    """The input is a zstd frame but no usable decoder is available."""
+                self.lines.append(f"- result: {truncate(' '.join(results), RESULT_MAX)}")
 
 
 def resolve_zstd() -> str:
@@ -171,7 +213,7 @@ def resolve_zstd() -> str:
     if "DPSK_ZSTD" in os.environ:
         candidate = os.environ.get("DPSK_ZSTD", "")
         if not candidate or not os.path.isfile(candidate) or not os.access(candidate, os.X_OK):
-            raise ZstdUnavailable("DPSK_ZSTD is set but is not an executable zstd binary")
+            raise FilterFailure("zstd-unavailable", "DPSK_ZSTD is set but is not an executable zstd binary")
         return candidate
 
     candidate = shutil.which("zstd")
@@ -180,50 +222,205 @@ def resolve_zstd() -> str:
     for candidate in ZSTD_FALLBACKS:
         if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
             return candidate
-    raise ZstdUnavailable("no executable zstd binary was found")
+    raise FilterFailure("zstd-unavailable", "no executable zstd binary was found")
 
 
-def read_session_bytes(path: str) -> bytes:
-    """Read plain JSONL or decode a file whose bytes identify a zstd frame."""
-    if path == "-":
-        return sys.stdin.buffer.read()
-
+def is_zstd_frame(path: str) -> bool:
     with open(path, "rb") as handle:
-        prefix = handle.read(4)
-        if prefix != ZSTD_MAGIC:
-            handle.seek(0)
-            return handle.read()
+        return handle.read(4) == ZSTD_MAGIC
+
+
+def decoded_lines(path: str, max_decompressed: int):
+    """Yield decoded text lines without materializing the whole payload.
+
+    Counts decompressed bytes against `max_decompressed` while streaming and
+    fails closed with `decompressed-too-large` when the cap is exceeded.
+    """
+    def stream(handle):
+        consumed = 0
+        for raw_line in handle:
+            consumed += len(raw_line)
+            if consumed > max_decompressed:
+                raise FilterFailure(
+                    "decompressed-too-large",
+                    f"decompressed session exceeds {max_decompressed} bytes",
+                )
+            yield raw_line.decode("utf-8", errors="replace")
+
+    if path == "-":
+        yield from stream(sys.stdin.buffer)
+        return
+    if not is_zstd_frame(path):
+        with open(path, "rb") as handle:
+            yield from stream(handle)
+        return
 
     zstd = resolve_zstd()
     try:
-        return subprocess.run(
-            [zstd, "-dc", path],
-            capture_output=True,
-            check=True,
-        ).stdout
-    except (OSError, subprocess.CalledProcessError) as exc:
-        raise ZstdUnavailable("zstd could not decode the session input") from exc
-
-
-def main():
-    if len(sys.argv) < 2:
-        print(__doc__)
-        sys.exit(2)
-    path = sys.argv[1]
+        process = subprocess.Popen([zstd, "-dc", "--", path], stdout=subprocess.PIPE)
+    except OSError as exc:
+        raise FilterFailure("zstd-unavailable", "zstd could not be started") from exc
     try:
-        raw = read_session_bytes(path)
-    except ZstdUnavailable as exc:
-        print(f"zstd-unavailable: {exc}", file=sys.stderr)
-        sys.exit(1)
-    events = []
-    for line in raw.decode("utf-8", errors="replace").splitlines():
+        yield from stream(process.stdout)
+    finally:
+        try:
+            process.stdout.close()
+        except OSError:
+            pass
+        if process.poll() is None:
+            process.terminate()
+        process.wait()
+
+
+def iter_events(path, max_decompressed):
+    for line in decoded_lines(path, max_decompressed):
         if not line.strip():
             continue
         try:
-            events.append(json.loads(line))
+            yield json.loads(line)
         except json.JSONDecodeError:
             continue
-    print(render(events))
+
+
+def render_streaming(path, max_decompressed):
+    renderer = StreamingRenderer()
+    for event in iter_events(path, max_decompressed):
+        renderer.feed(event)
+    if not renderer.header_done:
+        renderer.lines.insert(0, "# Session ?")
+        renderer.lines.insert(1, "- cwd: ?")
+        renderer.lines.insert(2, "- preset: ?")
+        renderer.lines.insert(3, "")
+    return renderer
+
+
+def chunk_header(session_id, session_digest, index, total):
+    return (
+        "<!-- dsh-memory-chunk\n"
+        f"session_id: {session_id}\n"
+        f"session_digest: {session_digest}\n"
+        f"chunk_index: {index}/{total}\n"
+        "-->\n"
+    )
+
+
+def write_chunks(transcript_path, chunk_dir, base_name, chunk_bytes, session_id, session_digest):
+    """Split the sanitized transcript into headered chunks at line boundaries.
+
+    Returns (chunk_paths, chunk_sizes). Each chunk is at most `chunk_bytes`
+    bytes of transcript body plus its header; at least one chunk is written
+    even for an empty transcript.
+    """
+    with open(transcript_path, "rb") as handle:
+        sizes = []
+        current = 0
+        for raw_line in handle:
+            if current > 0 and current + len(raw_line) > chunk_bytes:
+                sizes.append(current)
+                current = len(raw_line)
+            else:
+                current += len(raw_line)
+        sizes.append(current)
+    total = len(sizes)
+
+    chunk_paths = []
+    with open(transcript_path, "rb") as source:
+        for index, body_size in enumerate(sizes, start=1):
+            chunk_path = os.path.join(chunk_dir, f"{base_name}.chunk{index:02d}.md")
+            header = chunk_header(session_id, session_digest, index, total).encode("utf-8")
+            with open(chunk_path, "wb") as target:
+                os.chmod(chunk_path, 0o600)
+                target.write(header)
+                remaining = body_size
+                while remaining > 0:
+                    block = source.read(min(65536, remaining))
+                    if not block:
+                        break
+                    target.write(block)
+                    remaining -= len(block)
+            chunk_paths.append(chunk_path)
+    return chunk_paths, [os.path.getsize(path) for path in chunk_paths]
+
+
+def main():
+    args = sys.argv[1:]
+    chunk_dir = None
+    chunk_bytes = 0
+    session_digest = ""
+    max_decompressed = DEFAULT_MAX_DECOMPRESSED_BYTES
+    positional = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--chunk-dir":
+            index += 1
+            chunk_dir = args[index] if index < len(args) else None
+        elif arg == "--chunk-bytes":
+            index += 1
+            chunk_bytes = int(args[index]) if index < len(args) else 0
+        elif arg == "--session-digest":
+            index += 1
+            session_digest = args[index] if index < len(args) else ""
+        elif arg == "--max-decompressed-bytes":
+            index += 1
+            max_decompressed = int(args[index]) if index < len(args) else DEFAULT_MAX_DECOMPRESSED_BYTES
+        else:
+            positional.append(arg)
+        index += 1
+
+    if not positional:
+        print(__doc__)
+        sys.exit(2)
+    path = positional[0]
+    if chunk_dir is not None:
+        if chunk_bytes <= 0:
+            print("chunk-bytes-required: --chunk-dir requires a positive --chunk-bytes", file=sys.stderr)
+            sys.exit(1)
+        if not re.fullmatch(r"[0-9a-f]{64}", session_digest or ""):
+            print("session-digest-required: chunked mode needs the raw session sha256", file=sys.stderr)
+            sys.exit(1)
+
+    try:
+        renderer = render_streaming(path, max_decompressed)
+    except FilterFailure as exc:
+        print(f"{exc.code}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if chunk_dir is None:
+        print("\n".join(renderer.lines))
+        return
+
+    os.makedirs(chunk_dir, mode=0o700, exist_ok=True)
+    fd, transcript_path = tempfile.mkstemp(prefix=".transcript.", dir=chunk_dir)
+    total_bytes = 0
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            for line in renderer.lines:
+                encoded = line.encode("utf-8")
+                handle.write(encoded)
+                if not encoded.endswith(b"\n"):
+                    handle.write(b"\n")
+                    total_bytes += len(encoded) + 1
+                else:
+                    total_bytes += len(encoded)
+        os.chmod(transcript_path, 0o600)
+        base_name = os.path.basename(chunk_dir.rstrip("/"))
+        chunk_paths, chunk_sizes = write_chunks(
+            transcript_path, chunk_dir, base_name, chunk_bytes,
+            renderer.session_id or "?", session_digest,
+        )
+    finally:
+        try:
+            os.unlink(transcript_path)
+        except FileNotFoundError:
+            pass
+    print(json.dumps({
+        "session_id": renderer.session_id or "?",
+        "chunk_total": len(chunk_paths),
+        "chunk_paths": chunk_paths,
+        "chunk_sizes": chunk_sizes,
+        "transcript_bytes": total_bytes,
+    }, separators=(",", ":")))
 
 
 if __name__ == "__main__":

--- a/tests/run-memory-tests.sh
+++ b/tests/run-memory-tests.sh
@@ -15,6 +15,7 @@ node tests/test_dsh_memory_operation_lock.mjs
 node tests/test_dsh_memory_metadata.mjs
 node tests/test_dsh_memory_usage.mjs
 node tests/test_dsh_memory_context.mjs
+node tests/test_dsh_memory_retrieval_eval.mjs
 node tests/test_dsh_memory_tools.mjs
 node tests/test_dsh_memory_marketplace.mjs
 python3 tests/test_dsh_memory_sync_failures.py
@@ -31,6 +32,7 @@ zsh tests/test_dsh_memory_sync_zstd_failure.sh
 zsh tests/test_dsh_memory_sync_dry_run.sh
 zsh tests/test_dsh_memory_sync_lock.sh
 zsh tests/test_dsh_memory_sync_batch.sh
+zsh tests/test_dsh_memory_sync_chunks.sh
 zsh tests/test_dsh_memory_sync_preview.sh
 zsh tests/test_dsh_memory_sync_no_change.sh
 zsh tests/test_dsh_memory_backup.sh

--- a/tests/test_dsh_memory_init.sh
+++ b/tests/test_dsh_memory_init.sh
@@ -104,24 +104,67 @@ DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
 REFRESH_MEMORY_ROOT="$REFRESH_HOME/storages/memory"
 REFRESH_TEMPLATE="$FIXTURE_REPO/packages/dsh-memory/templates/scripts/filter_session.py"
 REFRESH_HELPER="$REFRESH_MEMORY_ROOT/scripts/filter_session.py"
+REFRESH_README_TEMPLATE="$FIXTURE_REPO/packages/dsh-memory/templates/README.md"
+REFRESH_README="$REFRESH_MEMORY_ROOT/README.md"
+REFRESH_GITIGNORE_TEMPLATE="$FIXTURE_REPO/packages/dsh-memory/templates/.sync/.gitignore"
+REFRESH_GITIGNORE="$REFRESH_MEMORY_ROOT/.sync/.gitignore"
 print -r -- '# refresh-marker-one' >> "$REFRESH_TEMPLATE"
 refresh_head_before="$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)"
 DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
 test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" != "$refresh_head_before"
-test "$(git -C "$REFRESH_MEMORY_ROOT" log -1 --format=%s)" = "Refresh helper scripts"
+test "$(git -C "$REFRESH_MEMORY_ROOT" log -1 --format=%s)" = "Refresh managed memory templates"
 test "$(git -C "$REFRESH_MEMORY_ROOT" diff-tree --no-commit-id --name-only -r HEAD)" = "scripts/filter_session.py"
 cmp -s "$REFRESH_TEMPLATE" "$REFRESH_HELPER"
 refresh_head_after="$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)"
 DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
 test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" = "$refresh_head_after"
 
+# All managed templates (README, .sync/.gitignore, helper) refresh in a
+# single "Refresh managed memory templates" commit listing exactly the
+# changed files.
+print -r -- '# refresh-readme-marker' >> "$REFRESH_README_TEMPLATE"
+print -r -- '# refresh-gitignore-marker' >> "$REFRESH_GITIGNORE_TEMPLATE"
+DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
+test "$(git -C "$REFRESH_MEMORY_ROOT" log -1 --format=%s)" = "Refresh managed memory templates"
+changed_files="$(git -C "$REFRESH_MEMORY_ROOT" diff-tree --no-commit-id --name-only -r HEAD | sort)"
+test "$changed_files" = "$(printf '.sync/.gitignore\nREADME.md')"
+cmp -s "$REFRESH_README_TEMPLATE" "$REFRESH_README"
+cmp -s "$REFRESH_GITIGNORE_TEMPLATE" "$REFRESH_GITIGNORE"
+refresh_head_after="$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)"
+DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
+test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" = "$refresh_head_after"
+
+# A dirty (uncommitted) managed template fails closed for every managed file.
 print -r -- '# uncommitted-helper-change' >> "$REFRESH_HELPER"
-print -r -- '# refresh-marker-two' >> "$REFRESH_TEMPLATE"
 if DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null 2>&1; then
   print -u2 -- "initializer overwrote a dirty helper"
   exit 1
 fi
 grep -q -- '# uncommitted-helper-change' "$REFRESH_HELPER"
+test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" = "$refresh_head_after"
+git -C "$REFRESH_MEMORY_ROOT" checkout -- scripts/filter_session.py
+
+print -r -- '# uncommitted-readme-change' >> "$REFRESH_README"
+if DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null 2>&1; then
+  print -u2 -- "initializer overwrote a dirty README"
+  exit 1
+fi
+grep -q -- '# uncommitted-readme-change' "$REFRESH_README"
+test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" = "$refresh_head_after"
+git -C "$REFRESH_MEMORY_ROOT" checkout -- README.md
+
+print -r -- '# uncommitted-gitignore-change' >> "$REFRESH_GITIGNORE"
+if DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null 2>&1; then
+  print -u2 -- "initializer overwrote a dirty .sync/.gitignore"
+  exit 1
+fi
+grep -q -- '# uncommitted-gitignore-change' "$REFRESH_GITIGNORE"
+test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" = "$refresh_head_after"
+git -C "$REFRESH_MEMORY_ROOT" checkout -- .sync/.gitignore
+
+# After reverting every dirty change, the initializer succeeds again and the
+# live copies match the (now stale) templates without a new commit.
+DSH_HOME="$REFRESH_HOME" "$INITIALIZER" >/dev/null
 test "$(git -C "$REFRESH_MEMORY_ROOT" rev-parse HEAD)" = "$refresh_head_after"
 
 print "dsh-memory initializer tests passed"

--- a/tests/test_dsh_memory_marketplace.mjs
+++ b/tests/test_dsh_memory_marketplace.mjs
@@ -11,7 +11,7 @@ const manifest = JSON.parse(await readFile(join(project, "package.json"), "utf8"
 const patch = await readFile(join(project, "packages/dsh-git-memory/cordis.patch.yml"), "utf8");
 
 assert.equal(manifest.name, "dsh-git-memory");
-assert.equal(manifest.version, "0.8.3");
+assert.equal(manifest.version, "0.8.4");
 assert.notEqual(manifest.private, true);
 assert.equal(manifest.main, "./packages/dsh-git-memory/lib/index.js");
 assert.equal(manifest.exports["."], "./packages/dsh-git-memory/lib/index.js");

--- a/tests/test_dsh_memory_marketplace.mjs
+++ b/tests/test_dsh_memory_marketplace.mjs
@@ -11,7 +11,7 @@ const manifest = JSON.parse(await readFile(join(project, "package.json"), "utf8"
 const patch = await readFile(join(project, "packages/dsh-git-memory/cordis.patch.yml"), "utf8");
 
 assert.equal(manifest.name, "dsh-git-memory");
-assert.equal(manifest.version, "0.8.4");
+assert.equal(manifest.version, "0.9.0");
 assert.notEqual(manifest.private, true);
 assert.equal(manifest.main, "./packages/dsh-git-memory/lib/index.js");
 assert.equal(manifest.exports["."], "./packages/dsh-git-memory/lib/index.js");

--- a/tests/test_dsh_memory_marketplace.mjs
+++ b/tests/test_dsh_memory_marketplace.mjs
@@ -11,7 +11,7 @@ const manifest = JSON.parse(await readFile(join(project, "package.json"), "utf8"
 const patch = await readFile(join(project, "packages/dsh-git-memory/cordis.patch.yml"), "utf8");
 
 assert.equal(manifest.name, "dsh-git-memory");
-assert.equal(manifest.version, "0.8.2");
+assert.equal(manifest.version, "0.8.3");
 assert.notEqual(manifest.private, true);
 assert.equal(manifest.main, "./packages/dsh-git-memory/lib/index.js");
 assert.equal(manifest.exports["."], "./packages/dsh-git-memory/lib/index.js");

--- a/tests/test_dsh_memory_metadata.mjs
+++ b/tests/test_dsh_memory_metadata.mjs
@@ -8,6 +8,8 @@ import {
   topicKey,
   resolveTopicConflict,
   isExpired,
+  auditRecords,
+  AUDIT_INVALID_METADATA_LIMIT,
 } from "../packages/dsh-memory/lib/memory-metadata.js";
 
 const canonical = `---
@@ -168,6 +170,75 @@ body`, "handbook/project.md");
   assert.equal(isExpired({ expires_at: "2020-01-01" }), true);
   assert.equal(isExpired({ expires_at: "2999-01-01" }), false);
   assert.equal(isExpired({}), false);
+}
+
+{
+  // v0.8.3: flow-style collections are rejected with a stable code; empty
+  // flow collections and canonical block lists stay valid.
+  assert.throws(
+    () => parseFrontMatter("---\nschema_version: 1\nid: x\ntags: [a, b]\n---\n", "handbook/x.md"),
+    (error) => error instanceof MetadataError && error.code === "flow-style-metadata",
+  );
+  assert.throws(
+    () => parseFrontMatter("---\nschema_version: 1\nid: x\nsource_rollouts: {a: 1}\n---\n", "handbook/x.md"),
+    (error) => error instanceof MetadataError && error.code === "flow-style-metadata",
+  );
+  const emptyFlow = parseFrontMatter("---\nschema_version: 1\nid: x\ntags: []\n---\n", "handbook/x.md");
+  assert.deepEqual(emptyFlow.tags, []);
+  const blockList = parseFrontMatter("---\nschema_version: 1\nid: x\ntags:\n  - a\n  - b\n---\n", "handbook/x.md");
+  assert.deepEqual(blockList.tags, ["a", "b"]);
+}
+
+{
+  // v0.8.3: the shared metadata audit reports valid/legacy/invalid records,
+  // duplicate ids, and truncates the invalid list to the documented limit.
+  const valid = (id) => `---\nschema_version: 1\nid: ${id}\n---\n正文\n`;
+  const audit = auditRecords([
+    { path: "handbook/a.md", content: valid("rec-a") },
+    { path: "handbook/b.md", content: valid("rec-b") },
+    { path: "handbook/legacy.md", content: "# plain markdown\nlegacy record\n" },
+    { path: "handbook/bad.md", content: "---\nschema_version: 2\nid: rec-bad\n---\n" },
+    { path: "handbook/flow.md", content: "---\nschema_version: 1\nid: rec-flow\ntags: [x]\n---\n" },
+    { path: "handbook/gone.md", content: null },
+    { path: "handbook/dup.md", content: valid("rec-a") },
+  ]);
+  assert.equal(audit.metadataValid, false);
+  assert.equal(audit.validMetadataCount, 3); // rec-a, rec-b, dup
+  assert.equal(audit.legacyMetadataCount, 1);
+  assert.equal(audit.invalidMetadataCount, 4); // bad + flow + gone + dup
+  assert.equal(audit.duplicateIdCount, 1);
+  assert.ok(audit.invalidMetadata.length <= AUDIT_INVALID_METADATA_LIMIT);
+  const byPath = new Map(audit.invalidMetadata.map((entry) => [entry.path, entry.code]));
+  assert.equal(byPath.get("handbook/bad.md"), "invalid-schema-version");
+  assert.equal(byPath.get("handbook/flow.md"), "flow-style-metadata");
+  assert.equal(byPath.get("handbook/gone.md"), "unreadable");
+  assert.equal(byPath.get("handbook/dup.md"), "duplicate-id");
+}
+
+{
+  // v0.8.3: a fully valid corpus audits clean; legacy records grandfather.
+  const audit = auditRecords([
+    { path: "handbook/a.md", content: "---\nschema_version: 1\nid: rec-a\n---\n" },
+    { path: "handbook/legacy.md", content: "# plain markdown\n" },
+  ]);
+  assert.equal(audit.metadataValid, true);
+  assert.equal(audit.validMetadataCount, 1);
+  assert.equal(audit.invalidMetadataCount, 0);
+  assert.equal(audit.legacyMetadataCount, 1);
+  assert.deepEqual(audit.invalidMetadata, []);
+}
+
+{
+  // v0.8.3: the invalid list is truncated to AUDIT_INVALID_METADATA_LIMIT
+  // while the count reflects every invalid record.
+  const flood = [];
+  for (let i = 0; i < AUDIT_INVALID_METADATA_LIMIT + 10; i += 1) {
+    flood.push({ path: `handbook/flood-${i}.md`, content: "---\nschema_version: 9\nid: x\n---\n" });
+  }
+  const audit = auditRecords(flood);
+  assert.equal(audit.metadataValid, false);
+  assert.equal(audit.invalidMetadataCount, AUDIT_INVALID_METADATA_LIMIT + 10);
+  assert.equal(audit.invalidMetadata.length, AUDIT_INVALID_METADATA_LIMIT);
 }
 
 console.log("dsh-memory metadata tests passed");

--- a/tests/test_dsh_memory_paths.mjs
+++ b/tests/test_dsh_memory_paths.mjs
@@ -37,6 +37,10 @@ await cp(
   join(project, "packages/dsh-memory/lib/sync-transaction.js"),
   join(fixture, "dsh-memory", "lib", "sync-transaction.js"),
 );
+await cp(
+  join(project, "packages/dsh-memory/lib/search-index.js"),
+  join(fixture, "dsh-memory", "lib", "search-index.js"),
+);
 await writeFile(join(fixture, "dsh-memory", "package.json"), '{"type":"module"}\n');
 
 const stubs = {

--- a/tests/test_dsh_memory_repository.mjs
+++ b/tests/test_dsh_memory_repository.mjs
@@ -80,7 +80,9 @@ We chose TypeScript for the codegen pipeline.\n`);
   assert.equal(hit.value.results[0].path, "handbook/project.md");
   assert.equal(hit.value.results[0].id, "project/codegen");
   assert.equal(hit.value.results[0].citation, "[source: handbook/project.md · id: project/codegen]");
-  assert.ok(hit.value.results[0].score >= 1);
+  // v0.9: score is the fused RRF contribution sum; components are exposed.
+  assert.ok(hit.value.results[0].score > 0);
+  assert.ok(hit.value.results[0].score_components !== undefined);
   const miss = await service.search({ query: "nonexistent-term" });
   assert.equal(miss.ok, true);
   assert.equal(miss.value.count, 0);

--- a/tests/test_dsh_memory_retrieval_eval.mjs
+++ b/tests/test_dsh_memory_retrieval_eval.mjs
@@ -1,0 +1,282 @@
+// v0.9.0 retrieval evaluation: a labeled query corpus over a mixed
+// Chinese/English memory fixture. Every case asserts recall against the
+// hybrid retrieval pipeline; index-state and degradation behavior are
+// asserted separately. The evaluation must pass in both retrieval modes
+// (hybrid with the SQLite derived index, and the degraded pure scan), so
+// results stay correct wherever node:sqlite or FTS5 is unavailable.
+import assert from "node:assert/strict";
+import { execFile as execFileCallback } from "node:child_process";
+import { chmod, lstat, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { MemoryRepository } from "../packages/dsh-memory/lib/index.js";
+import { stampOf } from "../packages/dsh-memory/lib/search-index.js";
+
+const execFile = promisify(execFileCallback);
+const git = async (root, args) => await execFile("/usr/bin/git", ["-C", root, ...args], { encoding: "utf8" });
+
+const root = await mkdtemp(join(tmpdir(), "dsh-memory-retrieval-eval-"));
+await git(root, ["init"]);
+await git(root, ["config", "user.name", "DSH Memory Retrieval Eval"]);
+await git(root, ["config", "user.email", "dsh-memory-eval@example.invalid"]);
+for (const dir of ["handbook", "rollouts", "archive", ".sync"]) await mkdir0(join(root, dir));
+async function mkdir0(path) {
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(path, { recursive: true });
+}
+await writeFile(join(root, "summary.md"), "navigation\n");
+await writeFile(join(root, ".last-sync"), "0\n");
+
+function record(dir, name, id, type, tags, body) {
+  return { dir, name, id, type, tags, body };
+}
+
+const CORPUS = [
+  record("handbook", "cjk-db-index.md", "infra/db-index", "decision", ["database", "performance"],
+    "数据库索引优化实践：B-tree 与 LSM-tree 的取舍，写放大与读放大的平衡。Database index optimization tradeoffs between B-tree and LSM-tree.\n"),
+  record("handbook", "cjk-cache.md", "infra/cache", "decision", ["cache"],
+    "缓存失效策略：旁路缓存与延迟双删，缓存穿透、缓存击穿、缓存雪崩的防线设计。\n"),
+  record("handbook", "launchd-setup.md", "ops/launchd", "procedure", ["macos", "scheduling"],
+    "launchd agent scheduling for the memory sync: StartCalendarInterval in the plist, throttle intervals, and keppalive rules.\n"),
+  record("handbook", "git-workflow.md", "ops/git", "decision", ["git", "workflow"],
+    "git workflow: short-lived branches, stacked PRs, rebase policy, and squash merges for release trains.\n"),
+  record("handbook", "redaction-policy.md", "sec/redaction", "constraint", ["security"],
+    "credential redaction policy: bearer tokens, sk- API keys, and AWS access keys are replaced with [REDACTED] before any model call.\n"),
+  record("handbook", "zstd-streaming.md", "infra/zstd", "procedure", ["compression"],
+    "zstd streaming decompression with bounded memory; the decoder fails closed when the payload exceeds the decompressed budget.\n"),
+  record("handbook", "fts-rrf.md", "infra/fts-rrf", "decision", ["search", "sqlite"],
+    "SQLite FTS5 trigram tokenizer combined with bigram derived terms, fused by reciprocal rank fusion for hybrid lexical retrieval.\n"),
+  record("handbook", "release-checklist.md", "ops/release", "procedure", ["release"],
+    "release checklist: version bump across packages, lockfile refresh, marketplace bundle sync, and the changelog entry.\n"),
+  record("handbook", "cjk-session-rules.md", "conv/zh-rules", "constraint", ["会话", "规范"],
+    "中文会话规范：长会话摘要压缩规则，会话日志在空闲一小时后进入候选窗口。\n"),
+  record("handbook", "perf-budget.md", "perf/budget", "decision", ["performance"],
+    "performance budget: p95 search latency stays under 50ms at ten thousand records.\n"),
+  record("handbook", "usage-decay.md", "perf/decay", "decision", ["usage"],
+    "usage decay: prior_usage_count decays by a 0.5 factor per generation so fresh generations rank first.\n"),
+  record("handbook", "cjk-concurrency.md", "infra/lock", "decision", ["并发", "lock"],
+    "中文并发控制：operation lock 采用目录锁，持有者消失且超过 30 秒后回收。\n"),
+  record("rollouts", "migrate-legacy.md", "mig/legacy", "procedure", ["migration"],
+    "legacy migration scans untracked markdown files and mints record ids from their paths.\n"),
+  record("rollouts", "preview-apply.md", "sync/preview", "procedure", ["preview"],
+    "preview staging is copied under .sync/previews and the operator applies it later via applyPreview.\n"),
+  record("rollouts", "chunked-delivery.md", "sync/chunks", "procedure", ["sync"],
+    "分块交付：候选会话按分块送入模型，未交付分块通过 pending-candidates v2 的 next_chunk 断点续传。\n"),
+  record("rollouts", "watermark-hold.md", "sync/watermark", "procedure", ["sync"],
+    "the watermark holds past rejected, deferred, and truncated windows until every candidate is fully resolved.\n"),
+  record("rollouts", "cjk-atomic-replace.md", "sync/atomic", "procedure", ["原子性"],
+    "中文原子替换：先把临时文件写完，再用 rename 原子替换目标，失败时清理临时文件。\n"),
+  record("rollouts", "token-redaction.md", "sec/query-redaction", "procedure", ["security"],
+    "query-string secrets such as ?api_key= and ?token= are redacted inside transcripts.\n"),
+  record("rollouts", "rrf-weights.md", "perf/rrf", "decision", ["search"],
+    "RRF weights: raw 2.0, FTS 1.0, coverage 1.0, usage 0.25, with the standard k=60 reciprocal constant.\n"),
+  record("rollouts", "launchd-restart.md", "ops/restart", "procedure", ["deployment"],
+    "restarting the launchd agent inside a safe window requires a backup first and a scan-only acceptance afterwards.\n"),
+  record("archive", "old-zstd-tmp.md", "old/zstd-tmp", "observation", ["deprecated"],
+    "deprecated: zstd temp files under /tmp were replaced by the staging worktree.\n"),
+  record("archive", "superseded-index.md", "old/mem-index", "observation", ["deprecated"],
+    "superseded in-memory index approach, replaced by the SQLite derived index.\n"),
+  record("archive", "cjk-old-chunks.md", "old/chunks", "observation", ["废弃"],
+    "旧版分块方案已废弃：整批截断改为逐候选交付。\n"),
+  record("archive", "legacy-fs.md", "old/fs-scan", "observation", ["legacy"],
+    "plain filesystem scan with no index, O(N) work per query.\n"),
+  record("archive", "old-decay.md", "old/decay", "observation", ["legacy"],
+    "old decay formula archived after the usage schema v2 migration.\n"),
+  record("archive", "deprecated-lock.md", "old/lock", "observation", ["deprecated"],
+    "deprecated flock-based lock replaced by the mkdir directory lock.\n"),
+];
+
+for (const entry of CORPUS) {
+  const front = [
+    "---",
+    "schema_version: 1",
+    `id: ${entry.id}`,
+    `type: ${entry.type}`,
+    "tags:",
+    ...entry.tags.map((tag) => `  - ${tag}`),
+    "---",
+    "",
+  ].join("\n");
+  await writeFile(join(root, entry.dir, entry.name), `${front}${entry.body}`);
+}
+await git(root, ["add", "."]);
+await writeFile(join(root, ".sync", ".gitignore"), "usage.json\nusage.lock/\n.usage.*.tmp\nsearch-index.sqlite\n.search-index.*.tmp\n");
+await git(root, ["add", "."]);
+await git(root, ["commit", "-m", "retrieval eval fixture"]);
+
+const service = new MemoryRepository({ root, __testOnly: true });
+const expectedStamp = stampOf((await git(root, ["ls-tree", "-r", "-z", "HEAD", "--", "summary.md", "handbook", "rollouts", "archive"])).stdout
+  .split("\0").filter(Boolean).map((entry) => {
+    const tab = entry.indexOf("\t");
+    const [meta, path] = [entry.slice(0, tab), entry.slice(tab + 1)];
+    const [, , object] = meta.split(" ");
+    return `${object} ${path}`;
+  }).sort().join("\n"));
+
+// ---------------------------------------------------------------- cases ----
+// Each case: query, optional scope, optional top1 (exact winner), and the
+// paths that must appear within `within` (default 3) results.
+const CASES = [
+  { q: "数据库索引优化实践", top1: "handbook/cjk-db-index.md" },
+  { q: "延迟双删", top1: "handbook/cjk-cache.md" },
+  { q: "reciprocal rank fusion", top1: "handbook/fts-rrf.md" },
+  { q: "pending-candidates v2", top1: "rollouts/chunked-delivery.md" },
+  { q: "StartCalendarInterval", top1: "handbook/launchd-setup.md" },
+  { q: "[REDACTED]", top1: "handbook/redaction-policy.md" },
+  { q: "旁路缓存", top1: "handbook/cjk-cache.md" },
+  { q: "写放大", top1: "handbook/cjk-db-index.md" },
+  { q: "rename 原子替换", top1: "rollouts/cjk-atomic-replace.md" },
+  { q: "mkdir directory lock", top1: "archive/deprecated-lock.md", scope: "archive" },
+  { q: "缓存", expect: ["handbook/cjk-cache.md"] },
+  { q: "雪崩", expect: ["handbook/cjk-cache.md"] },
+  { q: "索引", expect: ["handbook/cjk-db-index.md"] },
+  { q: "并发控制", expect: ["handbook/cjk-concurrency.md"] },
+  { q: "目录锁", expect: ["handbook/cjk-concurrency.md"] },
+  { q: "会话日志", expect: ["handbook/cjk-session-rules.md"] },
+  { q: "摘要压缩", expect: ["handbook/cjk-session-rules.md"] },
+  { q: "分块", expect: ["rollouts/chunked-delivery.md"] },
+  { q: "废弃", scope: "archive", expect: ["archive/cjk-old-chunks.md"] },
+  { q: "旧版分块", scope: "archive", expect: ["archive/cjk-old-chunks.md"] },
+  { q: "launchd", expect: ["handbook/launchd-setup.md", "rollouts/launchd-restart.md"] },
+  { q: "watermark", top1: "rollouts/watermark-hold.md" },
+  { q: "trigram", expect: ["handbook/fts-rrf.md"] },
+  { q: "checklist", top1: "handbook/release-checklist.md" },
+  { q: "preview", expect: ["rollouts/preview-apply.md"] },
+  { q: "decay", expect: ["handbook/usage-decay.md"] },
+  { q: "flock", scope: "archive", expect: ["archive/deprecated-lock.md"] },
+  { q: "untracked", expect: ["rollouts/migrate-legacy.md"] },
+  { q: "applyPreview", expect: ["rollouts/preview-apply.md"] },
+  { q: "zstd", top1: "handbook/zstd-streaming.md" },
+  { q: "constraint", expect: ["handbook/redaction-policy.md", "handbook/cjk-session-rules.md"] },
+  { q: "deployment", expect: ["rollouts/launchd-restart.md"] },
+  { q: "sec/redaction", top1: "handbook/redaction-policy.md" },
+  { q: "perf/budget", top1: "handbook/perf-budget.md" },
+  { q: "procedure", expect: ["handbook/launchd-setup.md"] },
+  { q: "数据库 OR 索引", expect: ["handbook/cjk-db-index.md"] },
+  { q: "cache eviction policy", expect: ["handbook/cjk-cache.md"] },
+  { q: "database index optimization", expect: ["handbook/cjk-db-index.md"] },
+  { q: "memory sync scheduling", expect: ["handbook/launchd-setup.md"] },
+  { q: "usage decay generation", top1: "handbook/usage-decay.md" },
+  { q: "search latency budget", expect: ["handbook/perf-budget.md"] },
+  { q: "sqlite", expect: ["handbook/fts-rrf.md"] },
+  { q: "rebase stacked", expect: ["handbook/git-workflow.md"] },
+  { q: "token", expect: ["rollouts/token-redaction.md"] },
+  { q: "backup", expect: ["rollouts/launchd-restart.md"] },
+  { q: "50ms", top1: "handbook/perf-budget.md" },
+  { q: "zstd", scope: "archive", expect: ["archive/old-zstd-tmp.md"] },
+  { q: "decay", scope: "archive", expect: ["archive/old-decay.md"] },
+  { q: "lock", scope: "archive", expect: ["archive/deprecated-lock.md"] },
+  { q: "chunks", scope: "archive", expect: ["archive/cjk-old-chunks.md"] },
+  { q: "streaming", expect: ["handbook/zstd-streaming.md"] },
+  { q: "迁移 untracked 文件", expect: ["rollouts/migrate-legacy.md"] },
+];
+
+let caseIndex = 0;
+for (const testCase of CASES) {
+  caseIndex += 1;
+  const response = await service.search({ query: testCase.q, scope: testCase.scope ?? "active", limit: 10 });
+  assert.equal(response.ok, true, `case ${caseIndex} (${testCase.q}) failed: ${JSON.stringify(response.error)}`);
+  const paths = response.value.results.map((entry) => entry.path);
+  if (testCase.top1 !== undefined) {
+    assert.equal(paths[0], testCase.top1, `case ${caseIndex} top1 (${testCase.q}): got ${paths.slice(0, 3).join(", ")}`);
+  }
+  for (const expected of testCase.expect ?? []) {
+    assert.ok(paths.slice(0, 3).includes(expected), `case ${caseIndex} recall (${testCase.q}): ${expected} not in top3, got ${paths.slice(0, 5).join(", ")}`);
+  }
+  assert.ok(response.value.retrieval, `case ${caseIndex}: retrieval metadata missing`);
+  assert.ok(["hybrid", "scan"].includes(response.value.retrieval.mode));
+  if (response.value.retrieval.mode === "hybrid") {
+    assert.ok(["fresh", "rebuilt"].includes(response.value.retrieval.indexState));
+    for (const entry of response.value.results) {
+      assert.ok(entry.score_components, `case ${caseIndex}: score_components missing`);
+      const components = entry.score_components;
+      const sum = components.raw + components.fts + components.coverage + components.usage;
+      assert.ok(Math.abs(sum - entry.score) < 1e-9, `case ${caseIndex}: fused score mismatch`);
+    }
+  } else {
+    assert.equal(response.value.retrieval.indexState, "degraded");
+  }
+}
+
+// Archive scope must hide active records and vice versa.
+const activeOnly = await service.search({ query: "zstd" });
+assert.ok(activeOnly.value.results.every((entry) => !entry.path.startsWith("archive/")));
+const archiveOnly = await service.search({ query: "zstd", scope: "archive" });
+assert.ok(archiveOnly.value.results.every((entry) => entry.path.startsWith("archive/")));
+
+// Exact-substring tier outranks usage reinforcement: after repeatedly using a
+// non-exact candidate, the exact-substring record still ranks first.
+for (let index = 0; index < 5; index += 1) {
+  await service.context({ query: "trigram", limit: 1 });
+}
+const exactBeatsUsage = await service.search({ query: "trigram tokenizer combined" });
+assert.equal(exactBeatsUsage.value.results[0].path, "handbook/fts-rrf.md");
+
+// memory_search never records usage: usage.json stays byte-identical across
+// searches.
+await service.context({ query: "缓存", limit: 1 });
+const usageBefore = await readFile(join(root, ".sync", "usage.json"), "utf8");
+await service.search({ query: "缓存" });
+await service.search({ query: "launchd" });
+const usageAfter = await readFile(join(root, ".sync", "usage.json"), "utf8");
+assert.equal(usageAfter, usageBefore);
+
+// The derived index exists, is 0600, is untracked (git-excluded), and its
+// stamp matches sha256(payloadTree(HEAD)).
+const indexPath = join(root, ".sync", "search-index.sqlite");
+const indexStat = await lstat(indexPath);
+assert.equal(indexStat.isFile(), true);
+assert.equal((indexStat.mode & 0o777), 0o600);
+const statusAfterSearch = (await git(root, ["status", "--porcelain"])).stdout;
+assert.equal(statusAfterSearch, "", `working tree dirty after search: ${statusAfterSearch}`);
+
+const hybridProbe = await service.search({ query: "缓存" });
+if (hybridProbe.value.retrieval.mode === "hybrid") {
+  assert.equal(hybridProbe.value.retrieval.stamp, expectedStamp);
+}
+
+// A new commit invalidates the stamp: the next search rebuilds, and the one
+// after that is fresh again.
+await writeFile(join(root, "handbook", "retrieval-extra.md"), `---
+schema_version: 1
+id: infra/retrieval-extra
+type: procedure
+tags:
+  - search
+---
+retrieval evaluation corpus extension: slop-resistant lexical ranking for a small memory corpus.
+`);
+await git(root, ["add", "."]);
+await git(root, ["commit", "-m", "extend retrieval fixture"]);
+const rebuilt = await service.search({ query: "slop-resistant" });
+if (rebuilt.value.retrieval.mode === "hybrid") {
+  assert.equal(rebuilt.value.retrieval.indexState, "rebuilt");
+  assert.equal(rebuilt.value.results[0].path, "handbook/retrieval-extra.md");
+  const freshAgain = await service.search({ query: "slop-resistant" });
+  assert.equal(freshAgain.value.retrieval.indexState, "fresh");
+} else {
+  assert.equal(rebuilt.value.results[0].path, "handbook/retrieval-extra.md");
+}
+
+// Degraded mode: a corrupt index plus an unwritable .sync directory forces
+// the pure-scan fallback with correct results.
+// Corrupt the SQLite header (not the tail: SQLite tolerates trailing junk
+// and would keep serving a "fresh" index), then make .sync unwritable so
+// the rebuild attempt fails and retrieval must fall back to the pure scan.
+const indexBytes = await readFile(indexPath);
+await writeFile(
+  indexPath,
+  Buffer.concat([Buffer.from("corrupt-header-junk-"), indexBytes.subarray(32)]),
+);
+await chmod(join(root, ".sync"), 0o500);
+try {
+  const degraded = await service.search({ query: "缓存" });
+  assert.equal(degraded.value.retrieval.mode, "scan");
+  assert.equal(degraded.value.retrieval.indexState, "degraded");
+  assert.ok(degraded.value.results.slice(0, 3).some((entry) => entry.path === "handbook/cjk-cache.md"));
+} finally {
+  await chmod(join(root, ".sync"), 0o700);
+}
+
+console.log(`dsh-memory retrieval evaluation passed (${CASES.length} labeled cases, corpus ${CORPUS.length} records)`);

--- a/tests/test_dsh_memory_sync_chunks.sh
+++ b/tests/test_dsh_memory_sync_chunks.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env zsh
+# v0.8.4 chunked-delivery contract tests:
+#   1. sanitized transcripts are split into headered chunks with stable
+#      provenance (session_id / session_digest / chunk_index), and the
+#      journal records the delivered chunk count;
+#   2. a session whose chunks exceed the model input cap is partially
+#      delivered, deferred via pending-candidates v2 (next_chunk), and
+#      resumes on the next run without re-paying for delivered chunks;
+#   3. raw-cap rejections at scan time hold the watermark without a run
+#      record (zero deliverable candidates);
+#   4. mixed batches (one deliverable + one oversized) are applied but the
+#      watermark stays held past the rejected candidate;
+#   5. decompressed-too-large rejections at filter time journal a zero-cost
+#      "rejected" run and hold the watermark.
+set -euo pipefail
+
+PROJECT_DIR="$(cd -- "$(dirname -- "$0")/.." && pwd -P)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/dsh-memory-sync-chunks.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+TEST_INTEGRATION="$TEST_ROOT/integrations/dsh"
+mkdir -p "$TEST_INTEGRATION" \
+  "$TEST_ROOT/packages/dsh-memory/templates/.sync" \
+  "$TEST_ROOT/packages/dsh-memory/templates/scripts"
+
+cp "$PROJECT_DIR/integrations/dsh/dsh-memory-sync" "$TEST_INTEGRATION/dsh-memory-sync"
+cp "$PROJECT_DIR/integrations/dsh/dsh-memory-init" "$TEST_INTEGRATION/dsh-memory-init"
+cp "$PROJECT_DIR/packages/dsh-memory/lib/sync-apply.py" "$TEST_INTEGRATION/sync-apply.py"
+cp "$PROJECT_DIR/packages/dsh-memory/templates/README.md" "$TEST_ROOT/packages/dsh-memory/templates/README.md"
+cp "$PROJECT_DIR/packages/dsh-memory/templates/.sync/.gitignore" "$TEST_ROOT/packages/dsh-memory/templates/.sync/.gitignore"
+cp "$PROJECT_DIR/packages/dsh-memory/templates/scripts/filter_session.py" "$TEST_ROOT/packages/dsh-memory/templates/scripts/filter_session.py"
+chmod +x "$TEST_INTEGRATION/dsh-memory-sync" "$TEST_INTEGRATION/dsh-memory-init"
+FILTER_SRC="$TEST_ROOT/packages/dsh-memory/templates/scripts/filter_session.py"
+
+PY=/usr/bin/python3
+OBS="$TEST_ROOT/observations"
+mkdir -p "$OBS"
+print -- 0 > "$OBS/counter"
+
+# Build a plain-text (non-zstd) session log with <turns> user messages of
+# <text_len> ASCII characters each, backdated out of the 1-hour idle window.
+make_session_log() {
+  "$PY" - "$@" <<'PYEOF'
+import json
+import pathlib
+import sys
+
+path, sid, turns, text_len = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
+lines = [{"type": "session", "id": sid, "data": {"id": sid, "cwd": "/tmp/demo", "agentPreset": "test"}}]
+for turn in range(1, turns + 1):
+    lines.append({
+        "type": "user/message",
+        "data": {"turn": turn, "content": [{"type": "text", "text": "turn %d payload: %s" % (turn, "a" * text_len)}]},
+    })
+pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
+pathlib.Path(path).write_text("\n".join(json.dumps(line) for line in lines) + "\n", encoding="utf-8")
+PYEOF
+}
+
+# fresh_env <name>: provision an isolated dsh-home + memory root + bin dir.
+SECTION=""
+fresh_env() {
+  SECTION="$1"
+  SECTION_DSH_HOME="$TEST_ROOT/$SECTION/dsh-home"
+  SECTION_ROOT="$TEST_ROOT/$SECTION/memory"
+  SECTION_BIN="$TEST_ROOT/$SECTION/bin"
+  mkdir -p "$SECTION_DSH_HOME/sessions" "$SECTION_BIN"
+  DSH_HOME="$SECTION_DSH_HOME" DSH_MEMORY_ROOT="$SECTION_ROOT" \
+    "$TEST_INTEGRATION/dsh-memory-init" >/dev/null
+  touch -t 200001010000 "$SECTION_ROOT/.last-sync"
+}
+
+# Headless DSH stub: captures how many chunk files the manifest delivered on
+# each run and copies them out for inspection (they live under the staging
+# input tree, which the host deletes after the child exits).
+write_stub() {
+  local bin="$1"
+  cat > "$bin/dsh" <<EOF
+#!/bin/zsh
+set -euo pipefail
+for last; do :; done
+prompt="\$last"
+seq=\$(cat "$OBS/counter" 2>/dev/null || print 0)
+seq=\$((seq + 1))
+print -- "\$seq" > "$OBS/counter"
+out="$OBS/run-\$seq"
+mkdir -p "\$out"
+print -r -- "\$prompt" > "\$out/prompt.txt"
+manifest="\$(printf '%s' "\$prompt" | /usr/bin/python3 -c 'import sys,re; m=re.search(r"候选会话清单：(\\S+?)（", sys.stdin.read()); print(m.group(1) if m else "")')"
+n=0
+if [[ -n "\$manifest" && -f "\$manifest" ]]; then
+  while IFS= read -r chunk; do
+    [[ -n "\$chunk" ]] || continue
+    n=\$((n + 1))
+    cp -- "\$chunk" "\$out/chunk-\$n.md"
+  done < "\$manifest"
+fi
+print -- "\$n" > "\$out/chunk-count.txt"
+mkdir -p handbook
+print -- "stub consolidation run \$seq" > handbook/consolidated.md
+EOF
+  chmod +x "$bin/dsh"
+}
+
+run_sync() {
+  # $1 = extra env assignments already set by the caller via env prefix.
+  env \
+    HOME="$TEST_ROOT/home" \
+    DSH_HOME="$SECTION_DSH_HOME" \
+    DSH_MEMORY_ROOT="$SECTION_ROOT" \
+    DSH_BIN="$SECTION_BIN/dsh" \
+    DPSK_MEMORY_SYNC_HELPER="$TEST_INTEGRATION/sync-apply.py" \
+    PATH="$SECTION_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    "$@" \
+    zsh "$TEST_INTEGRATION/dsh-memory-sync"
+}
+
+JOURNAL_TMP="$TEST_ROOT/journal.json"
+journal_records() {
+  "$PY" - "$SECTION_ROOT" "$JOURNAL_TMP" <<'PYEOF'
+import json
+import pathlib
+import sys
+
+runs = pathlib.Path(sys.argv[1]) / ".sync" / "runs"
+records = [json.loads(p.read_text()) for p in sorted(runs.glob("*.json"))]
+pathlib.Path(sys.argv[2]).write_text(json.dumps(records), encoding="utf-8")
+PYEOF
+}
+
+watermark_held() {
+  [[ -f "$SECTION_ROOT/.last-sync" && ! -s "$SECTION_ROOT/.last-sync" ]]
+}
+
+watermark_advanced() {
+  [[ -s "$SECTION_ROOT/.last-sync" ]]
+}
+
+# --- 1. Chunk headers: provenance header on every chunk + journal counts ---
+fresh_env headers
+HEADERS_SESSION="$SECTION_DSH_HOME/sessions/sess-headers/session.jsonl.zstd"
+make_session_log "$HEADERS_SESSION" "sess-headers" 6 200
+touch -t 200001010001 "$HEADERS_SESSION"
+write_stub "$SECTION_BIN"
+run_sync DSH_MEMORY_MAX_CHUNK_BYTES=300 >/dev/null
+
+HEADERS_T="$("$PY" - "$OBS/run-1" "$HEADERS_SESSION" <<'PYEOF'
+import hashlib
+import pathlib
+import re
+import sys
+
+run_dir = pathlib.Path(sys.argv[1])
+session = pathlib.Path(sys.argv[2])
+digest = hashlib.sha256(session.read_bytes()).hexdigest()
+chunks = sorted(run_dir.glob("chunk-*.md"))
+assert len(chunks) >= 3, len(chunks)
+seen = []
+total = None
+for chunk in chunks:
+    match = re.match(
+        r"<!-- dsh-memory-chunk\n"
+        r"session_id: (.*)\n"
+        r"session_digest: ([0-9a-f]{64})\n"
+        r"chunk_index: (\d+)/(\d+)\n"
+        r"-->",
+        chunk.read_text(),
+    )
+    assert match, chunk.read_text()[:200]
+    assert match.group(1) == "sess-headers", match.group(1)
+    assert match.group(2) == digest, (match.group(2), digest)
+    seen.append(int(match.group(3)))
+    total = int(match.group(4))
+assert seen == list(range(1, len(chunks) + 1)), seen
+assert total == len(chunks), (total, len(chunks))
+print(total)
+PYEOF
+)"
+
+journal_records
+"$PY" - "$JOURNAL_TMP" "$HEADERS_T" <<'PYEOF'
+import json
+import pathlib
+import sys
+
+records = json.loads(pathlib.Path(sys.argv[1]).read_text())
+applied = [r for r in records if r["status"] == "applied"]
+assert len(applied) == 1, records
+record = applied[0]
+assert record["candidate_sessions"] == 1, record
+assert record["processed_chunk_count"] == int(sys.argv[2]), record
+assert record["deferred_candidate_count"] == 0, record
+assert record["rejected_candidate_count"] == 0, record
+PYEOF
+watermark_advanced
+[[ ! -e "$SECTION_ROOT/.sync/pending-candidates.json" ]]
+print -- "1. chunk header provenance + journal counts: ok"
+
+# --- 2. Deferred resume: model input cap defers chunks, next run resumes ---
+fresh_env resume
+RESUME_SESSION="$SECTION_DSH_HOME/sessions/sess-resume/session.jsonl.zstd"
+make_session_log "$RESUME_SESSION" "sess-resume" 6 200
+touch -t 200001010001 "$RESUME_SESSION"
+write_stub "$SECTION_BIN"
+RESUME_DIGEST="$(shasum -a 256 -- "$RESUME_SESSION" | awk '{print $1}')"
+probe="$("$PY" "$FILTER_SRC" "$RESUME_SESSION" \
+  --chunk-dir "$TEST_ROOT/probe-resume" --chunk-bytes 300 \
+  --session-digest "$RESUME_DIGEST" --max-decompressed-bytes 1048576)"
+RESUME_TOTAL="$(printf '%s' "$probe" | "$PY" -c 'import json,sys; print(json.load(sys.stdin)["chunk_total"])')"
+FIRST_SIZE="$(printf '%s' "$probe" | "$PY" -c 'import json,sys; print(json.load(sys.stdin)["chunk_sizes"][0])')"
+
+# Run 1: only the first chunk fits the model input batch cap; the rest is
+# deferred and recorded in pending-candidates v2.
+run_sync DSH_MEMORY_MAX_CHUNK_BYTES=300 "DSH_MEMORY_MAX_CANDIDATE_BYTES=$((FIRST_SIZE + 10))" >/dev/null
+[[ "$(cat "$OBS/run-2/chunk-count.txt")" == "1" ]]
+journal_records
+"$PY" - "$JOURNAL_TMP" "$RESUME_TOTAL" <<'PYEOF'
+import json
+import pathlib
+import sys
+
+records = json.loads(pathlib.Path(sys.argv[1]).read_text())
+applied = [r for r in records if r["status"] == "applied"]
+assert len(applied) == 1, records
+record = applied[0]
+assert record["processed_chunk_count"] == 1, record
+assert record["deferred_candidate_count"] == 1, record
+assert record["rejected_candidate_count"] == 0, record
+assert record["processed_sessions"] == 1, record
+PYEOF
+watermark_held
+"$PY" - "$SECTION_ROOT" "$RESUME_DIGEST" "$RESUME_TOTAL" <<'PYEOF'
+import json
+import pathlib
+import re
+import sys
+
+root, digest, total = sys.argv[1], sys.argv[2], int(sys.argv[3])
+state = json.loads((pathlib.Path(root) / ".sync" / "pending-candidates.json").read_text())
+assert state["schema_version"] == 2, state
+entries = state["entries"]
+assert len(entries) == 1, entries
+entry = list(entries.values())[0]
+assert entry["digest"] == digest, entry
+assert entry["next_chunk"] == 2, entry
+assert entry["chunk_total"] == total, entry
+assert entry["complete"] is False, entry
+assert re.fullmatch(r"[0-9a-f]{64}", digest)
+PYEOF
+
+# Run 2: the session resumes from chunk 2, delivers the remainder, and the
+# watermark finally advances past the fully resolved window.
+run_sync DSH_MEMORY_MAX_CHUNK_BYTES=300 >/dev/null
+[[ "$(cat "$OBS/run-3/chunk-count.txt")" == "$((RESUME_TOTAL - 1))" ]]
+"$PY" - "$OBS/run-3" <<'PYEOF'
+import pathlib
+import re
+import sys
+
+run_dir = pathlib.Path(sys.argv[1])
+indices = []
+total = None
+for chunk in sorted(run_dir.glob("chunk-*.md")):
+    match = re.search(r"chunk_index: (\d+)/(\d+)", chunk.read_text())
+    assert match, chunk
+    indices.append(int(match.group(1)))
+    total = int(match.group(2))
+assert indices == list(range(2, total + 1)), (indices, total)
+PYEOF
+journal_records
+"$PY" - "$JOURNAL_TMP" "$RESUME_TOTAL" <<'PYEOF'
+import json
+import pathlib
+import sys
+
+records = json.loads(pathlib.Path(sys.argv[1]).read_text())
+applied = [r for r in records if r["status"] == "applied"]
+assert len(applied) == 2, records
+resume = applied[1]
+assert resume["processed_chunk_count"] == int(sys.argv[2]) - 1, resume
+assert resume["deferred_candidate_count"] == 0, resume
+assert resume["rejected_candidate_count"] == 0, resume
+PYEOF
+watermark_advanced
+[[ ! -e "$SECTION_ROOT/.sync/pending-candidates.json" ]]
+print -- "2. deferred resume via pending-candidates v2: ok (chunk_total=$RESUME_TOTAL)"
+
+# --- 3. Raw cap at scan time, all candidates oversized: zero-cost hold ---
+fresh_env rawcap
+BIG_SESSION="$SECTION_DSH_HOME/sessions/sess-big/session.jsonl.zstd"
+make_session_log "$BIG_SESSION" "sess-big" 6 200
+"$PY" - "$BIG_SESSION" <<'PYEOF'
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[1]).write_bytes(b"x" * 4096)
+PYEOF
+touch -t 200001010001 "$BIG_SESSION"
+write_stub "$SECTION_BIN"
+rawcap_out="$(run_sync DSH_MEMORY_MAX_SESSION_FILE_BYTES=1024)"
+print -r -- "$rawcap_out" | grep -q "0 deliverable session(s), 1 rejected by the raw cap; watermark held."
+journal_records
+[[ "$(cat "$JOURNAL_TMP")" == "[]" ]]
+watermark_held
+[[ ! -e "$SECTION_ROOT/.sync/pending-candidates.json" ]]
+print -- "3. raw-cap zero-deliverable hold: ok"
+
+# --- 4. Mixed batch: deliverable applied, oversized rejected, watermark held ---
+fresh_env rawmix
+MIX_SMALL="$SECTION_DSH_HOME/sessions/sess-small/session.jsonl.zstd"
+MIX_BIG="$SECTION_DSH_HOME/sessions/sess-oversize/session.jsonl.zstd"
+make_session_log "$MIX_SMALL" "sess-small" 2 60
+make_session_log "$MIX_BIG" "sess-oversize" 6 200
+"$PY" - "$MIX_BIG" <<'PYEOF'
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[1]).write_bytes(b"x" * 4096)
+PYEOF
+touch -t 200001010001 "$MIX_SMALL" "$MIX_BIG"
+write_stub "$SECTION_BIN"
+counter_before="$(cat "$OBS/counter")"
+run_sync DSH_MEMORY_MAX_SESSION_FILE_BYTES=1024 >/dev/null
+[[ "$(cat "$OBS/counter")" == "$((counter_before + 1))" ]]
+journal_records
+"$PY" - "$JOURNAL_TMP" <<'PYEOF'
+import json
+import pathlib
+import sys
+
+records = json.loads(pathlib.Path(sys.argv[1]).read_text())
+applied = [r for r in records if r["status"] == "applied"]
+assert len(applied) == 1, records
+record = applied[0]
+assert record["candidate_sessions"] == 1, record
+assert record["rejected_candidate_count"] == 1, record
+assert record["deferred_candidate_count"] == 0, record
+PYEOF
+# The run applied memory changes, but the rejected candidate keeps the
+# watermark from advancing past the window.
+watermark_held
+print -- "4. mixed batch apply + watermark held past rejection: ok"
+
+# --- 5. Decompressed-too-large: filter-stage rejection journals a zero-cost run ---
+fresh_env decomp
+DECOMP_SESSION="$SECTION_DSH_HOME/sessions/sess-decomp/session.jsonl.zstd"
+make_session_log "$DECOMP_SESSION" "sess-decomp" 4 400
+touch -t 200001010001 "$DECOMP_SESSION"
+write_stub "$SECTION_BIN"
+counter_before="$(cat "$OBS/counter")"
+decomp_out="$(run_sync DSH_MEMORY_MAX_SESSION_DECOMPRESSED_BYTES=500)"
+[[ "$(cat "$OBS/counter")" == "$counter_before" ]]
+print -r -- "$decomp_out" | grep -q "0 chunk(s) delivered (0 deferred, 1 rejected); watermark held."
+journal_records
+"$PY" - "$JOURNAL_TMP" <<'PYEOF'
+import json
+import pathlib
+import sys
+
+records = json.loads(pathlib.Path(sys.argv[1]).read_text())
+assert len(records) == 1, records
+record = records[0]
+assert record["status"] == "rejected", record
+assert record["rejected_candidate_count"] == 1, record
+assert record["deferred_candidate_count"] == 0, record
+assert record["processed_chunk_count"] == 0, record
+PYEOF
+watermark_held
+print -- "5. decompressed-too-large rejection: ok"
+
+print -- "dsh-memory sync chunked delivery tests passed"

--- a/tests/test_dsh_memory_sync_dry_run.sh
+++ b/tests/test_dsh_memory_sync_dry_run.sh
@@ -1,16 +1,23 @@
 #!/usr/bin/env zsh
 set -euo pipefail
 
+# v0.8.3: --scan-only (and its deprecated --dry-run alias) is the zero-Provider
+# acceptance path. It reports the candidate scan without starting DSH, without
+# acquiring the operation lock, without writing a journal or pending state,
+# and without advancing the .last-sync watermark.
+
 PROJECT_DIR="$(cd -- "$(dirname -- "$0")/.." && pwd -P)"
 SYNC_SOURCE="$PROJECT_DIR/integrations/dsh/dsh-memory-sync"
 INITIALIZER="$PROJECT_DIR/integrations/dsh/dsh-memory-init"
-TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/dsh-memory-sync-dry-run.XXXXXX")"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/dsh-memory-sync-scan-only.XXXXXX")"
 TEST_INTEGRATION="$TEST_ROOT/integrations/dsh"
 TEST_HOME="$TEST_ROOT/home"
 TEST_DSH_HOME="$TEST_ROOT/dsh-home"
 TEST_MEMORY_ROOT="$TEST_ROOT/memory"
 TEST_BIN="$TEST_ROOT/bin"
-OUTPUT="$TEST_ROOT/dry-run-output.txt"
+CANARY_HIT="$TEST_ROOT/canary-hit"
+OUT="$TEST_ROOT/scan-out.txt"
+ERR="$TEST_ROOT/scan-err.txt"
 
 mkdir -p "$TEST_INTEGRATION" "$TEST_HOME" "$TEST_DSH_HOME/sessions" "$TEST_MEMORY_ROOT" "$TEST_BIN"
 cp "$SYNC_SOURCE" "$TEST_INTEGRATION/dsh-memory-sync"
@@ -23,43 +30,126 @@ mkdir -p "${DSH_MEMORY_ROOT:?}"
 EOF
 chmod +x "$TEST_INTEGRATION/dsh-memory-init"
 
-DSH_HOME="$TEST_DSH_HOME" DSH_MEMORY_ROOT="$TEST_MEMORY_ROOT" "$INITIALIZER" >/dev/null
-rm -f "$TEST_MEMORY_ROOT/.last-sync"
+# Real initializer (via env) prepares the git-backed memory root; the stub
+# above is what dsh-memory-sync itself invokes in scan-only mode (and it must
+# never be reached, because scan-only skips the initializer).
+DSH_HOME="$TEST_DSH_HOME" DSH_MEMORY_ROOT="$TEST_MEMORY_ROOT" \
+  GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@example.com \
+  GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@example.com \
+  "$INITIALIZER" >/dev/null
 
-cat > "$TEST_BIN/dsh" <<'EOF'
+# A canary DSH stub: if any sync path reaches DSH, the test fails loudly.
+cat > "$TEST_BIN/dsh" <<EOF
 #!/bin/zsh
-set -euo pipefail
-printf 'synthetic memory entry\n' > handbook/synthetic.md
-exit 0
+print -r -- hit > "$CANARY_HIT"
+exit 42
 EOF
 chmod +x "$TEST_BIN/dsh"
 
-# dry-run must report the would-be changes without applying them.
+run_sync() {
+  env \
+    HOME="$TEST_HOME" \
+    DSH_HOME="$TEST_DSH_HOME" \
+    DSH_MEMORY_ROOT="$TEST_MEMORY_ROOT" \
+    DSH_BIN="$TEST_BIN/dsh" \
+    DPSK_MEMORY_SYNC_HELPER="$TEST_INTEGRATION/sync-apply.py" \
+    GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@example.com \
+    GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@example.com \
+    PATH="$TEST_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
+    zsh "$TEST_INTEGRATION/dsh-memory-sync" "$@"
+}
+
+assert_no_side_effects() {
+  test ! -e "$CANARY_HIT"
+  test ! -e "$TEST_MEMORY_ROOT/.sync/operation.lock"
+  test ! -e "$TEST_MEMORY_ROOT/.sync/active-run.json"
+  test ! -d "$TEST_MEMORY_ROOT/.sync/runs"
+  test ! -e "$TEST_MEMORY_ROOT/.sync/last-run.json"
+  test ! -e "$TEST_MEMORY_ROOT/.sync/pending-candidates.json"
+  local dirty
+  dirty="$(git -C "$TEST_MEMORY_ROOT" status --porcelain | grep -v '^ D \.last-sync$' || true)"
+  [[ -z "$dirty" ]] || { print -u2 -- "unexpected live-root changes: $dirty"; exit 1; }
+}
+
+# --- Case 1: first run (no watermark) — JSON reports an absent watermark and
+# zero candidates, with zero side effects.
+rm -f "$TEST_MEMORY_ROOT/.last-sync"
 set +e
-env \
-  HOME="$TEST_HOME" \
-  DSH_HOME="$TEST_DSH_HOME" \
-  DSH_MEMORY_ROOT="$TEST_MEMORY_ROOT" \
-  DSH_BIN="$TEST_BIN/dsh" \
-  DPSK_MEMORY_SYNC_HELPER="$TEST_INTEGRATION/sync-apply.py" \
-  PATH="$TEST_BIN:/usr/bin:/bin:/usr/sbin:/sbin" \
-  zsh "$TEST_INTEGRATION/dsh-memory-sync" --dry-run > "$OUTPUT" 2>&1
+run_sync --scan-only --json > "$OUT" 2> "$ERR"
 rc=$?
 set -e
 test "$rc" = "0"
-grep -q -- 'dry-run' "$OUTPUT"
-grep -q -- 'handbook/synthetic.md' "$OUTPUT"
-
-# dry-run must not modify the live root, journal, or watermark. The .sync
-# directory itself is created by the initializer (with its .gitignore), but a
-# dry-run must not create a lock, an active-run record, or any run journal.
-test ! -e "$TEST_MEMORY_ROOT/handbook/synthetic.md"
-test ! -e "$TEST_MEMORY_ROOT/.sync/operation.lock"
-test ! -e "$TEST_MEMORY_ROOT/.sync/active-run.json"
-test ! -d "$TEST_MEMORY_ROOT/.sync/runs"
-test ! -e "$TEST_MEMORY_ROOT/.sync/last-run.json"
+/usr/bin/python3 - "$OUT" <<'PY'
+import json, sys
+data = json.loads(open(sys.argv[1]).read())
+assert data["ok"] is True and data["scanOnly"] is True, data
+assert data["watermark"] == "absent", data
+assert data["candidateSessions"] == 0, data
+assert data["candidates"] == [], data
+PY
+assert_no_side_effects
 test ! -e "$TEST_MEMORY_ROOT/.last-sync"
-# The marker was removed by the test itself; nothing else in the live root may change.
-test "$(git -C "$TEST_MEMORY_ROOT" status --porcelain | grep -v '^ D .last-sync$' | wc -l | tr -d ' ')" = "0"
 
-print -- "dsh-memory sync dry-run tests passed"
+# --- Case 2: watermark present plus one idle (2h-old) session newer than the
+# marker — JSON reports the candidate with bytes and digest, the watermark
+# state stays "set", and the marker mtime is untouched.
+git -C "$TEST_MEMORY_ROOT" checkout -- .last-sync
+touch -t "$(date -v-3H +%Y%m%d%H%M)" "$TEST_MEMORY_ROOT/.last-sync"
+SESSION_DIR="$TEST_DSH_HOME/sessions/sess-scan-0001"
+mkdir -p "$SESSION_DIR"
+printf 'synthetic session payload\n' > "$SESSION_DIR/session.jsonl.zstd"
+touch -t "$(date -v-2H +%Y%m%d%H%M)" "$SESSION_DIR/session.jsonl.zstd"
+marker_mtime_before="$(stat -f %m "$TEST_MEMORY_ROOT/.last-sync")"
+set +e
+run_sync --scan-only --json > "$OUT" 2> "$ERR"
+rc=$?
+set -e
+test "$rc" = "0"
+/usr/bin/python3 - "$OUT" "$SESSION_DIR/session.jsonl.zstd" <<'PY'
+import json, sys
+data = json.loads(open(sys.argv[1]).read())
+expected = sys.argv[2]
+assert data["ok"] is True and data["scanOnly"] is True, data
+assert data["watermark"] == "set", data
+assert data["candidateSessions"] == 1, data
+assert data["candidates"][0]["path"] == expected, data
+assert data["candidates"][0]["bytes"] > 0, data
+digest = data["candidates"][0]["digest"]
+assert len(digest) == 64 and all(c in "0123456789abcdef" for c in digest), data
+PY
+marker_mtime_after="$(stat -f %m "$TEST_MEMORY_ROOT/.last-sync")"
+test "$marker_mtime_before" = "$marker_mtime_after"
+assert_no_side_effects
+test -e "$TEST_MEMORY_ROOT/.last-sync"
+
+# Text mode reports the same scan in prose.
+set +e
+run_sync --scan-only > "$OUT" 2> "$ERR"
+rc=$?
+set -e
+test "$rc" = "0"
+grep -q -- 'scan-only: 1 candidate session(s)' "$OUT" "$ERR" || {
+  print -u2 -- "text scan-only output missing candidate summary"; exit 1; }
+assert_no_side_effects
+
+# --- Case 3: --dry-run is a deprecated alias of --scan-only: it warns on
+# stderr, never runs the model, and has zero side effects.
+set +e
+run_sync --dry-run > "$OUT" 2> "$ERR"
+rc=$?
+set -e
+test "$rc" = "0"
+grep -q -- '--dry-run is deprecated' "$ERR"
+assert_no_side_effects
+
+# --- Case 4: --scan-only and --preview are mutually exclusive (fail-closed).
+set +e
+run_sync --scan-only --preview some-id > "$OUT" 2> "$ERR"
+rc=$?
+set -e
+test "$rc" != "0"
+grep -q -- 'mutually exclusive' "$ERR"
+assert_no_side_effects
+
+rm -rf "$TEST_ROOT"
+print -- "dsh-memory sync scan-only tests passed"

--- a/tests/test_dsh_memory_sync_preview.sh
+++ b/tests/test_dsh_memory_sync_preview.sh
@@ -1,7 +1,8 @@
 #!/bin/zsh
 # v0.3.1: the sync wrapper can capture a candidate diff as a pending preview
-# (--preview), apply a preview (--apply-preview), discard it
-# (--discard-preview), and emit a machine-parseable dry-run report (--json).
+# (--preview), apply a preview (--apply-preview), and discard it
+# (--discard-preview). v0.8.3: --dry-run is a deprecated alias of --scan-only
+# and no longer emits a diff report.
 set -euo pipefail
 
 PROJECT_DIR="$(cd -- "$(dirname -- "$0")/.." && pwd -P)"
@@ -104,35 +105,30 @@ set -e
 test "$mutex_rc" != "0"
 grep -q -- "mutually exclusive" "$TEST_ROOT/mutex.out"
 
-# 5. --dry-run --json emits a single machine-parseable JSON document. After the
-#    apply above there are no new changes, so the report has empty lists but
-#    must still be valid JSON with the schema shape.
-run_sync --dry-run --json >"$TEST_ROOT/dry.json" 2>/dev/null
+# 5. --dry-run is a deprecated alias of --scan-only: it warns on stderr and
+#    emits the scan-only JSON contract (no diff report, no model run). The
+#    session above is still an unconsumed candidate because preview apply
+#    never advances the watermark.
+marker_before="$(stat -f %m "$TEST_MEMORY_ROOT/.last-sync")"
+run_sync --dry-run --json >"$TEST_ROOT/dry.json" 2>"$TEST_ROOT/dry.err"
+grep -q -- '--dry-run is deprecated' "$TEST_ROOT/dry.err"
 /usr/bin/python3 - "$TEST_ROOT/dry.json" <<'PY'
 import json
 import sys
 report = json.load(open(sys.argv[1]))
 assert report["ok"] is True, report
-assert report["dryRun"] is True, report
-assert isinstance(report["changedPaths"], list), report
-assert isinstance(report["added"], list), report
-assert isinstance(report["modified"], list), report
-assert isinstance(report["deleted"], list), report
-assert "candidateSessions" in report, report
+assert report["scanOnly"] is True, report
+assert report["watermark"] == "set", report
+assert report["candidateSessions"] == 1, report
+assert isinstance(report["candidates"], list) and len(report["candidates"]) == 1, report
 PY
 
-# 6. A fresh dry-run --json over a new session change reports the paths.
-rm -f "$TEST_MEMORY_ROOT/.last-sync"
-touch -t 200001010000 "$TEST_MEMORY_ROOT/.last-sync"
-: > "$TEST_DSH_HOME/sessions/session.jsonl.zstd"
-touch -t 200001010001 "$TEST_DSH_HOME/sessions/session.jsonl.zstd"
-run_sync --dry-run --json >"$TEST_ROOT/dry2.json" 2>/dev/null
-/usr/bin/python3 - "$TEST_ROOT/dry2.json" <<'PY'
-import json
-import sys
-report = json.load(open(sys.argv[1]))
-assert "handbook/preview-cli.md" in report["changedPaths"], report
-assert report["candidateSessions"] == 1, report
-PY
+# 6. The alias run stays side-effect free: no lock, journal, pending state,
+#    and the watermark is untouched.
+test ! -e "$TEST_MEMORY_ROOT/.sync/operation.lock"
+test ! -e "$TEST_MEMORY_ROOT/.sync/active-run.json"
+test ! -d "$TEST_MEMORY_ROOT/.sync/runs"
+test ! -e "$TEST_MEMORY_ROOT/.sync/pending-candidates.json"
+test "$(stat -f %m "$TEST_MEMORY_ROOT/.last-sync")" = "$marker_before"
 
 print -- "dsh-memory sync preview tests passed"

--- a/tools/public-tree-check.mjs
+++ b/tools/public-tree-check.mjs
@@ -102,6 +102,7 @@ const allowed = new Set([
   "tests/test_dsh_memory_sync_disabled.sh",
   "tests/test_dsh_memory_sync_dry_run.sh",
   "tests/test_dsh_memory_sync_env.sh",
+  "tests/test_dsh_memory_sync_chunks.sh",
   "tests/test_dsh_memory_sync_zstd_failure.sh",
   "tests/test_dsh_memory_sync_lock.sh",
   "tests/test_dsh_memory_sync_batch.sh",
@@ -242,9 +243,9 @@ try {
     }
 
     const expectedManifestVersions = {
-      "package.json": "0.8.3",
-      "packages/dsh-memory/package.json": "0.8.3",
-      "packages/dsh-memory-ui/package.json": "0.8.3",
+      "package.json": "0.8.4",
+      "packages/dsh-memory/package.json": "0.8.4",
+      "packages/dsh-memory-ui/package.json": "0.8.4",
     };
     for (const manifestPath of Object.keys(expectedManifestVersions)) {
       const content = readSnapshotText(snapshot, manifestPath);

--- a/tools/public-tree-check.mjs
+++ b/tools/public-tree-check.mjs
@@ -58,6 +58,7 @@ const allowed = new Set([
   "packages/dsh-memory/lib/memory-tree.js",
   "packages/dsh-memory/lib/operation-lock.js",
   "packages/dsh-memory/lib/safe-clear.py",
+  "packages/dsh-memory/lib/search-index.js",
   "packages/dsh-memory/lib/sync-apply.py",
   "packages/dsh-memory/lib/sync-transaction.js",
   "packages/dsh-memory/templates/README.md",
@@ -72,6 +73,7 @@ const allowed = new Set([
   "packages/dsh-git-memory/lib/memory-usage.js",
   "packages/dsh-git-memory/lib/operation-lock.js",
   "packages/dsh-git-memory/lib/safe-clear.py",
+  "packages/dsh-git-memory/lib/search-index.js",
   "packages/dsh-git-memory/lib/sync-apply.py",
   "packages/dsh-git-memory/lib/sync-transaction.js",
   "packages/dsh-memory-ui/package.json",
@@ -100,6 +102,7 @@ const allowed = new Set([
   "tests/test_dsh_memory_sync_transaction.mjs",
   "tests/test_dsh_memory_runtime.sh",
   "tests/test_dsh_memory_sync_disabled.sh",
+  "tests/test_dsh_memory_retrieval_eval.mjs",
   "tests/test_dsh_memory_sync_dry_run.sh",
   "tests/test_dsh_memory_sync_env.sh",
   "tests/test_dsh_memory_sync_chunks.sh",
@@ -243,9 +246,9 @@ try {
     }
 
     const expectedManifestVersions = {
-      "package.json": "0.8.4",
-      "packages/dsh-memory/package.json": "0.8.4",
-      "packages/dsh-memory-ui/package.json": "0.8.4",
+      "package.json": "0.9.0",
+      "packages/dsh-memory/package.json": "0.9.0",
+      "packages/dsh-memory-ui/package.json": "0.9.0",
     };
     for (const manifestPath of Object.keys(expectedManifestVersions)) {
       const content = readSnapshotText(snapshot, manifestPath);

--- a/tools/public-tree-check.mjs
+++ b/tools/public-tree-check.mjs
@@ -242,9 +242,9 @@ try {
     }
 
     const expectedManifestVersions = {
-      "package.json": "0.8.2",
-      "packages/dsh-memory/package.json": "0.8.2",
-      "packages/dsh-memory-ui/package.json": "0.8.1",
+      "package.json": "0.8.3",
+      "packages/dsh-memory/package.json": "0.8.3",
+      "packages/dsh-memory-ui/package.json": "0.8.3",
     };
     for (const manifestPath of Object.keys(expectedManifestVersions)) {
       const content = readSnapshotText(snapshot, manifestPath);

--- a/tools/sync-marketplace-bundle.mjs
+++ b/tools/sync-marketplace-bundle.mjs
@@ -16,6 +16,7 @@ const hostFiles = [
   "memory-tree.js",
   "memory-usage.js",
   "operation-lock.js",
+  "search-index.js",
   "safe-clear.py",
   "sync-apply.py",
   "sync-transaction.js",


### PR DESCRIPTION
## Summary

- **Hybrid retrieval pipeline**: `memory.search()` and `memory.context()` fuse a full-corpus lexical scan with a derived SQLite FTS5 index via reciprocal-rank fusion (k=60; weights raw 2.0 / fts 1.0 / coverage 1.0 / usage 0.25), with an exact-substring precedence tier above fused scoring.
- **Derived search index** `.sync/search-index.sqlite` (0600): `content_fts` (trigram) + `terms_fts` (unicode61 over English words and CJK bigrams), stamped `sha256(payloadTree(HEAD))`, built into a temp DB and atomically renamed, git-excluded via `.git/info/exclude`.
- **Retrieval API metadata**: responses gain `retrieval` (`mode`: hybrid|scan; `indexState`: fresh|rebuilt|degraded; `stamp`); results gain `score` + `score_components`.
- **Transparent degradation**: missing/stale/corrupt index auto-rebuilds; rebuild failure (e.g. unwritable `.sync`) falls back to pure scan with `indexState: degraded` and identical results.
- **Evaluation suite**: 52 labeled queries over a 26-record mixed Chinese/English corpus — top-1/top-3 recall, scope filtering, exact-tier precedence, usage invariants, 0600 permissions, working-tree cleanliness, stamp invalidation on new commits, corrupt-index degradation.

## Test plan

- [x] `tests/test_dsh_memory_retrieval_eval.mjs` — 52 labeled cases + index-state/degradation blocks (all green)
- [x] Full regression: 29 prior items + new eval + chunks test (small-batch runs; two environment-only issues documented below)
- [x] `test:public-tree`, `test:guards`, secret scan
- [x] Marketplace bundle synchronized (11 files, includes `search-index.js`)

## Notes

- `SYNC_POLICY_VERSION` intentionally unchanged (`v0.8.4`): 0.9.0 changes retrieval only, not the sync contract.
- `test_dsh_memory_sync_no_change.sh` and the post-pass hang in `test_dsh_memory_tools.mjs` reproduce identically on the 0.8.4 baseline commit in this sandbox (brokered `find -newer` limitation / lingering runtime handles); they are not regressions from this change.