### PR TITLE
feat: v0.9.1 explicit conflict chain, handbook provenance gate, enrichment preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-09-01
+
+### Added
+
+- Explicit-only conflict resolution: `resolveTopicConflict()` no longer
+  applies implicit "newest wins" ordering. A winner emerges only through an
+  explicit `supersedes` link (the named record is projected out), records
+  linked by `conflicts_with` block each other until an operator resolves the
+  conflict, and zero-or-multiple contenders resolve to "unresolved" instead
+  of silently discarding knowledge. Expired records and records whose own
+  status is `superseded`/`archived` still project out. Mirrored in the host
+  staging helper.
+- Handbook provenance gate (fail-closed): newly added `handbook/` records in
+  a staged diff must carry at least one of `source_rollouts`,
+  `source_session_digest`, or `source_hash`; the host rejects the whole diff
+  with `missing-provenance` otherwise. Baseline (pre-existing) records are
+  exempt so legacy migration keeps working. The consolidation prompt and the
+  managed template README document the requirement and the explicit
+  supersession/conflict workflow.
+- Independent enrichment preview: `--preview` metadata now splits
+  `changed_paths` into `enrichment_paths` (under `handbook/`) and
+  `consolidation_paths`, and the run output reports both categories so
+  distilled handbook knowledge can be reviewed separately from
+  consolidation edits. `--apply-preview` still applies the captured diff
+  atomically. Staging-diff failures now print structured error details
+  (path/phase/run id) for faster diagnosis.
+- Release acceptance checklist: `docs/release-checklist.md` gains the local
+  deployment acceptance sequence — backup, quiesce the memory-sync
+  LaunchAgent only, safe-window DSH restart, zero-Provider `--scan-only
+  --json` acceptance, scheduler reload, and a hybrid-retrieval smoke check.
+
+### Changed
+
+- Default retrieval scope: the `active` scope (and the legacy read path)
+  now excludes records whose own status is `superseded` or `archived`;
+  expired records were already skipped. Retired knowledge remains
+  retrievable through `scope: "all"` or the archive directory.
+- `SYNC_POLICY_VERSION` advances to `v0.9.1`: the staging contract changed
+  (provenance gate, explicit conflict chain).
+
 ## [0.9.0] - 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ not expose the filesystem root or execute Git directly.
 
 ## Compatibility
 
-`v0.9.0` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
+`v0.9.1` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
 tested and locally integrated with a consistently pinned `0.1.0-rc.7` graph:
 
 | Component | Supported version |

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -72,3 +72,37 @@ real memory store.
 - Confirm the public repository and package targets before the external action.
 - If any check is skipped or cannot run, stop the release and document the
   blocker instead of treating the release as verified.
+
+## 6. Deployment acceptance (local DSH host)
+
+Perform during a safe window while no memory sync is in flight. These steps
+deploy the new bundle to a local DSH installation and prove it works with
+zero Provider involvement before re-enabling the scheduler.
+
+1. **Backup first.** Export a backup of the live memory root via the
+   `dsh-memory-backup` flow and verify the archive restores into a temporary
+   directory. Never deploy without a recovery point.
+2. **Quiesce the scheduler.** Unload only the memory-sync LaunchAgent
+   (label from `integrations/dsh/dsh-memory-sync.plist.example`), for example
+   `launchctl bootout gui/$UID/<label>`. DSH itself keeps running; no other
+   agent is touched.
+3. **Restart DSH in the safe window.** Restart the local DSH service so the
+   new plugin bundle loads, then confirm the settings page shows a healthy
+   repository.
+4. **Zero-Provider acceptance.** Run:
+
+   ```zsh
+   integrations/dsh/dsh-memory-sync --scan-only --json
+   ```
+
+   Assert `ok:true`, `scanOnly:true`, sensible `candidateSessions` and
+   `candidateBytes`, correct `watermark` state, and that `.last-sync` and
+   the journal are untouched afterwards. No DSH headless run, provider
+   process, or paid call may be spawned by this mode.
+5. **Reload the scheduler.** `launchctl bootstrap gui/$UID/<plist>` and watch
+   the next scheduled run acquire the operation lock, complete, and journal a
+   healthy `status`.
+6. **Retrieval smoke.** Query through `memory_search` and confirm hybrid
+   retrieval metadata is present (`retrieval.mode` is `hybrid` or `scan`,
+   `indexState` is `fresh`/`rebuilt`/`degraded`) and results are correct.
+   A persistent `degraded` state is a rollback signal.

--- a/integrations/dsh/dsh-memory-sync
+++ b/integrations/dsh/dsh-memory-sync
@@ -31,7 +31,7 @@ MARKER="$DSH_MEMORY_ROOT/.last-sync"
 PENDING_CANDIDATES="$DSH_MEMORY_ROOT/.sync/pending-candidates.json"
 DSH_BIN="${DSH_BIN:-dsh}"
 DSH_PERMISSION_MODE="${DSH_PERMISSION_MODE:-workspace-write}"
-SYNC_POLICY_VERSION="${DSH_MEMORY_SYNC_POLICY_VERSION:-v0.8.4}"
+SYNC_POLICY_VERSION="${DSH_MEMORY_SYNC_POLICY_VERSION:-v0.9.1}"
 # Model input batch caps: how much sanitized transcript is delivered per run.
 MAX_CANDIDATE_SESSIONS="${DSH_MEMORY_MAX_CANDIDATE_SESSIONS:-10}"
 MAX_CANDIDATE_BYTES="${DSH_MEMORY_MAX_CANDIDATE_BYTES:-8388608}"
@@ -820,7 +820,7 @@ STAGING_PROMPT="你是 dsh-memory 的定时记忆整合代理，现在执行一�
 
 步骤：
 1. 逐行读取候选会话清单中的临时脱敏转录，按 README「提炼与整合」一节的提炼要求提炼（无高信号则输出 NO_SIGNAL 并跳过该会话）。
-3. 全部提炼完成后，严格按 README「提炼与整合」一节的整合要求执行 diff 式整合：与旧条目矛盾的内容覆盖旧条目（绝不叠加）、过时内容降级到 $STAGING/archive/、用户稳定偏好同步进 $STAGING/summary.md。summary.md 最终必须不超过 12 KiB；超出时压缩重复过程和细节，不得静默超过预算。
+3. 全部提炼完成后，严格按 README「提炼与整合」一节的整合要求执行 diff 式整合：与旧条目矛盾的内容覆盖旧条目（绝不叠加）——新条目须声明 supersedes: <旧条目 id> 并把旧条目 status 置为 superseded；无法合并的矛盾用 conflicts_with 显式标注；过时内容降级到 $STAGING/archive/；新增 $STAGING/handbook/ 条目必须至少携带 source_rollouts、source_session_digest、source_hash 之一（否则宿主校验会拒绝整个 diff，错误码 missing-provenance）。用户稳定偏好同步进 $STAGING/summary.md。summary.md 最终必须不超过 12 KiB；超出时压缩重复过程和细节，不得静默超过预算。
 4. 不要执行 git、不要更新同步水位；宿主会负责提交和记录。
 
 收尾用一句话汇报：处理了几个会话、合并了几条记忆。"
@@ -874,7 +874,8 @@ difference=""
 if ! difference="$(sync_apply diff --staging "$STAGING" --manifest "$MANIFEST" --run-id "$RUN_ID")"; then
   diff_error="$(json_error_code "$difference")"
   write_failure_record "$diff_error" validating "$difference"
-  print -u2 -- "dsh-memory-sync: staging diff failed: $diff_error"
+  diff_details="$(printf '%s' "$difference" | /usr/bin/python3 -c 'import json,sys; d=json.load(sys.stdin).get("error",{}); print(" ".join(f"{k}={v}" for k,v in sorted(d.items()) if k not in ("code",)))' 2>/dev/null || true)"
+  print -u2 -- "dsh-memory-sync: staging diff failed: $diff_error${diff_details:+ ($diff_details)}"
   rm -rf -- "$STAGING_PARENT"
   exit 1
 fi
@@ -950,7 +951,25 @@ if [[ "$PREVIEW_MODE" == "1" ]]; then
   cp -R -- "$STAGING" "$preview_root/staging"
   chmod -R 700 "$preview_root/staging" 2>/dev/null || true
   PREVIEW_EXPIRES=$(date -u -v+7d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '+7 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
-  preview_meta="{\"preview_id\":\"$PREVIEW_ID\",\"created_at\":\"$STARTED_AT\",\"expires_at\":\"$PREVIEW_EXPIRES\",\"candidate_sessions\":$CANDIDATE_SESSIONS,\"changed_paths\":[$(printf '%s' "$changed_paths" | /usr/bin/sed 's/\([^,]*\)/"\1"/g')],\"status\":\"pending\"}"
+  # v0.9.1: enrichment (handbook/) is an independent preview category. The
+  # changed-path set is split so operators can see — and reason about — the
+  # distilled handbook knowledge separately from consolidation edits to
+  # rollouts/, archive/, and summary.md. apply-preview still applies the
+  # whole captured diff atomically; the split is a review affordance.
+  typeset -a ENRICHMENT_PARTS CONSOLIDATION_PARTS
+  ENRICHMENT_PARTS=()
+  CONSOLIDATION_PARTS=()
+  for preview_path in "${(@s:,:)changed_paths}"; do
+    [[ -z "$preview_path" ]] && continue
+    if [[ "$preview_path" == handbook/* ]]; then
+      ENRICHMENT_PARTS+=("$preview_path")
+    else
+      CONSOLIDATION_PARTS+=("$preview_path")
+    fi
+  done
+  enrichment_paths="$(json_list "${(j:,:)ENRICHMENT_PARTS}")"
+  consolidation_paths="$(json_list "${(j:,:)CONSOLIDATION_PARTS}")"
+  preview_meta="{\"preview_id\":\"$PREVIEW_ID\",\"created_at\":\"$STARTED_AT\",\"expires_at\":\"$PREVIEW_EXPIRES\",\"candidate_sessions\":$CANDIDATE_SESSIONS,\"changed_paths\":[$(printf '%s' "$changed_paths" | /usr/bin/sed 's/\([^,]*\)/"\1"/g')],\"enrichment_paths\":$enrichment_paths,\"consolidation_paths\":$consolidation_paths,\"status\":\"pending\"}"
   sync_apply write-preview --root "$DSH_MEMORY_ROOT" --run-id "$PREVIEW_ID" --preview-json "$preview_meta" >/dev/null || {
     print -u2 -- "dsh-memory-sync: preview write failed"
     rm -rf -- "$STAGING_PARENT"
@@ -958,6 +977,8 @@ if [[ "$PREVIEW_MODE" == "1" ]]; then
   }
   echo "dsh-memory-sync: preview $PREVIEW_ID created (pending, expires $PREVIEW_EXPIRES)."
   echo "dsh-memory-sync: changed: $changed_paths"
+  echo "dsh-memory-sync: enrichment (handbook/): $( [[ "${#ENRICHMENT_PARTS}" == "0" ]] && print "(none)" || print "${(j:,:)ENRICHMENT_PARTS}" )"
+  echo "dsh-memory-sync: consolidation: $( [[ "${#CONSOLIDATION_PARTS}" == "0" ]] && print "(none)" || print "${(j:,:)CONSOLIDATION_PARTS}" )"
   rm -rf -- "$STAGING_PARENT"
   exit 0
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-git-memory",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-git-memory",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "workspaces": [
         "packages/dsh-memory",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-git-memory",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": false,
   "description": "A local Git-backed long-term memory bundle for DeepSeek Harness",
   "type": "module",

--- a/packages/dsh-git-memory/lib/index.js
+++ b/packages/dsh-git-memory/lib/index.js
@@ -931,6 +931,7 @@ export class MemoryRepository {
         path: file,
         id: recordId,
         type: metadata?.type ?? null,
+        status: metadata?.status ?? null,
         tags: metadata?.tags ?? [],
         updatedAt: metadata?.updated_at ?? null,
         rawBody: body,
@@ -966,6 +967,7 @@ export class MemoryRepository {
     const { records, warnings: scanWarnings } = await this.scanRecords(root, usage);
     const results = [];
     for (const record of records) {
+      if (!includeArchive && (record.status === "superseded" || record.status === "archived")) continue;
       const score = this.rawLexicalScore(record, tokens);
       if (score <= 0) continue;
       const first = record.__bodyLower.indexOf(tokens[0]);
@@ -997,14 +999,20 @@ export class MemoryRepository {
    * when the index is unavailable.
    */
   async retrieve(root, query, scope, usage, warnings) {
-    const inScope = scope === "archive"
+    // v0.9.1: the default active scope also excludes records whose own
+    // status is superseded or archived (expired records are already skipped
+    // at scan time), so retired knowledge stays retrievable only through an
+    // explicit "all" scope or the archive directory itself.
+    const inPathScope = scope === "archive"
       ? (path) => path.startsWith("archive/")
       : scope === "active"
         ? (path) => !path.startsWith("archive/")
         : () => true;
+    const inRecordScope = (record) =>
+      inPathScope(record.path) && (scope !== "active" || (record.status !== "superseded" && record.status !== "archived"));
     const { records, warnings: scanWarnings } = await this.scanRecords(root, usage);
-    warnings.push(...scanWarnings.filter((warning) => inScope(warning.path)));
-    const candidates = records.filter((record) => inScope(record.path));
+    warnings.push(...scanWarnings.filter((warning) => inPathScope(warning.path)));
+    const candidates = records.filter((record) => inRecordScope(record));
     const tokens = query.toLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 0);
     if (tokens.length === 0) throw memoryError("search-invalid-request");
     for (const record of candidates) {

--- a/packages/dsh-git-memory/lib/index.js
+++ b/packages/dsh-git-memory/lib/index.js
@@ -143,7 +143,7 @@ function startSummaryWatcher(onChange) {
     lastSeen = { mtimeMs: stat.mtimeMs, size: stat.size };
   } catch {}
   let debounceTimer = null;
-  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS }, (current) => {
+  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS, persistent: false }, (current) => {
     // A zeroed stat means the file is temporarily gone; the snapshot
     // retention in buildMemorySectionText covers it, so do not refresh.
     if (!current || (current.size === 0 && current.mtimeMs === 0)) return;

--- a/packages/dsh-git-memory/lib/memory-metadata.js
+++ b/packages/dsh-git-memory/lib/memory-metadata.js
@@ -263,26 +263,40 @@ export function topicKey(metadata) {
 }
 
 /**
- * Deterministic conflict resolution. Given records that share a topicKey,
- * pick the winner in a stable order that never depends on file order:
+ * Explicit-only conflict resolution (v0.9.1). Given records that share a
+ * topicKey, a winner emerges only through explicit declarations — implicit
+ * "newest wins" ordering is gone because it silently discarded knowledge:
  *   1. expired records never win (lazy expiry projection);
- *   2. status precedence active > candidate > conflicted > superseded >
- *      archived;
- *   3. newest updated_at wins;
- *   4. lexicographically smallest id breaks the tie.
- * Returns the winning record, or null when no record is eligible.
+ *   2. records whose own status is superseded or archived are projected out;
+ *   3. a record named in another eligible record's `supersedes` is excluded
+ *      (explicit supersession);
+ *   4. records linked by `conflicts_with` block each other: neither side can
+ *      win until an operator resolves the conflict explicitly;
+ *   5. exactly one contender remains -> that record wins; zero or multiple
+ *      contenders -> null (unresolved, surfaced as a conflict instead of
+ *      being silently resolved by file order or recency).
+ * Returns the winning record, or null when resolution is not explicit.
  */
 export function resolveTopicConflict(records, now = Date.now()) {
-  const eligible = records.filter((record) => !isExpired(record, now));
+  const eligible = records.filter(
+    (record) => !isExpired(record, now) && record.status !== "superseded" && record.status !== "archived",
+  );
   if (eligible.length === 0) return null;
-  const precedence = Object.freeze({ active: 0, candidate: 1, conflicted: 2, superseded: 3, archived: 4 });
-  return [...eligible].sort((left, right) => {
-    const statusDiff = (precedence[left.status ?? "candidate"] ?? 1) - (precedence[right.status ?? "candidate"] ?? 1);
-    if (statusDiff !== 0) return statusDiff;
-    const dateDiff = String(right.updated_at ?? "").localeCompare(String(left.updated_at ?? ""));
-    if (dateDiff !== 0) return dateDiff;
-    return String(left.id).localeCompare(String(right.id));
-  })[0];
+  const byId = new Map(eligible.map((record) => [record.id, record]));
+  const excluded = new Set();
+  const linkedIds = (record, field) =>
+    [record[field]].filter((id) => typeof id === "string" && id.length > 0 && byId.has(id));
+  for (const record of eligible) {
+    for (const id of linkedIds(record, "supersedes")) excluded.add(id);
+  }
+  for (const record of eligible) {
+    for (const id of linkedIds(record, "conflicts_with")) {
+      excluded.add(record.id);
+      excluded.add(id);
+    }
+  }
+  const contenders = eligible.filter((record) => !excluded.has(record.id));
+  return contenders.length === 1 ? contenders[0] : null;
 }
 
 export const AUDIT_INVALID_METADATA_LIMIT = 20;

--- a/packages/dsh-git-memory/lib/sync-apply.py
+++ b/packages/dsh-git-memory/lib/sync-apply.py
@@ -555,9 +555,9 @@ def parse_metadata_scalar(value):
 
 def parse_record_metadata(text, relative):
     if relative == "summary.md" or not relative.endswith(".md") or not path_is_payload(relative):
-        return None
+        return None, None
     if not (text.startswith("---\n") or text.startswith("---\r\n")):
-        return None
+        return None, None
     match = re.match(r"^---\r?\n([\s\S]*?)\r?\n---\r?\n?", text)
     if match is None:
         raise SyncError("invalid-metadata")
@@ -617,7 +617,7 @@ def parse_record_metadata(text, relative):
             not isinstance(values[field], str) or not DATE_RE.fullmatch(values[field])
         ):
             raise SyncError("invalid-metadata")
-    return record_id
+    return record_id, values
 
 
 def metadata_topic_key(record):
@@ -643,21 +643,39 @@ def is_record_expired(record, now=None):
 
 
 def resolve_topic_conflict(records, now=None):
-    """Deterministic winner among records sharing a topic key. Expired records
-    never win; status precedence active > candidate > conflicted > superseded >
-    archived; newest updated_at wins; smallest id breaks ties."""
-    precedence = {"active": 0, "candidate": 1, "conflicted": 2, "superseded": 3, "archived": 4}
-    eligible = [record for record in records if not is_record_expired(record, now)]
+    """Explicit-only conflict resolution (v0.9.1). A winner emerges only
+    through explicit declarations; implicit "newest wins" ordering is gone:
+      1. expired records never win (lazy expiry projection);
+      2. records whose own status is superseded or archived project out;
+      3. a record named in another eligible record's supersedes is excluded;
+      4. records linked by conflicts_with block each other;
+      5. exactly one contender remains -> winner; otherwise None."""
+    eligible = [
+        record for record in records
+        if not is_record_expired(record, now) and record.get("status") not in ("superseded", "archived")
+    ]
     if not eligible:
         return None
-    return sorted(
-        eligible,
-        key=lambda record: (
-            precedence.get(record.get("status") or "candidate", 1),
-            -(record.get("updated_at") or ""),
-            record.get("id") or "",
-        ),
-    )[0]
+    by_id = {record.get("id"): record for record in eligible if isinstance(record.get("id"), str)}
+    excluded = set()
+
+    def linked(record, field):
+        value = record.get(field)
+        if isinstance(value, str) and value and value in by_id and by_id[value] is not record:
+            return value
+        return None
+
+    for record in eligible:
+        target = linked(record, "supersedes")
+        if target is not None:
+            excluded.add(target)
+    for record in eligible:
+        target = linked(record, "conflicts_with")
+        if target is not None:
+            excluded.add(record.get("id"))
+            excluded.add(target)
+    contenders = [record for record in eligible if record.get("id") not in excluded]
+    return contenders[0] if len(contenders) == 1 else None
 
 
 def duplicate_error(record_id, first_path, second_path, phase, run_id=None):
@@ -691,7 +709,7 @@ def scan_duplicate_ids(directory_fd, file_iterator, phase, run_id=None):
             text = content.decode("utf-8")
         except UnicodeDecodeError:
             continue
-        record_id = parse_record_metadata(text, relative)
+        record_id, _values = parse_record_metadata(text, relative)
         if record_id is not None:
             if record_id in ids:
                 raise duplicate_error(record_id, ids[record_id], relative, phase, run_id)
@@ -702,6 +720,7 @@ def validate_staging_limits(staging_fd, manifest, phase="staging-diff", run_id=N
     baseline = {entry["path"]: entry for entry in manifest.get("entries", [])}
     observed = {}
     ids = {}
+    meta_by_path = {}
     for relative, entry_stat in walk_staging_tree(staging_fd):
         if entry_stat.st_size > MAX_FILE_BYTES:
             raise SyncError("file-too-large")
@@ -725,15 +744,32 @@ def validate_staging_limits(staging_fd, manifest, phase="staging-diff", run_id=N
             raise SyncError("binary-file")
         if relative == "summary.md" and len(content) > SUMMARY_BUDGET_BYTES:
             raise SyncError("summary-too-large")
-        record_id = parse_record_metadata(text, relative)
+        record_id, values = parse_record_metadata(text, relative)
         if record_id is not None:
             if record_id in ids:
                 raise duplicate_error(record_id, ids[record_id], relative, phase, run_id)
             ids[record_id] = relative
         observed[relative] = {"size": len(content), "sha256": hashlib.sha256(content).hexdigest()}
+        if record_id is not None:
+            meta_by_path[relative] = values
     added = [path for path in observed if path not in baseline and path_is_payload(path)]
     modified = [path for path in observed if path in baseline and baseline[path].get("sha256") != observed[path]["sha256"] and path_is_payload(path)]
     deleted = [path for path in baseline if path not in observed and path_is_payload(path)]
+    # v0.9.1: newly added handbook records must carry provenance — at least
+    # one of source_rollouts, source_session_digest, or source_hash. Existing
+    # (baseline) handbook records are exempt so legacy migration keeps
+    # working; the model's new consolidated knowledge must stay traceable.
+    for path in added:
+        if not path.startswith("handbook/") or not path.endswith(".md"):
+            continue
+        values = meta_by_path.get(path)
+        has_provenance = values is not None and (
+            bool(values.get("source_rollouts"))
+            or (isinstance(values.get("source_session_digest"), str) and bool(values["source_session_digest"]))
+            or (isinstance(values.get("source_hash"), str) and bool(values["source_hash"]))
+        )
+        if not has_provenance:
+            raise SyncError("missing-provenance", {"path": path, "phase": phase, "run_id": run_id} if run_id is not None else {"path": path, "phase": phase})
     if len(added) > MAX_ADDED_FILES:
         raise SyncError("too-many-files")
     changed_bytes = sum(observed[path]["size"] for path in added + modified)

--- a/packages/dsh-memory-ui/package.json
+++ b/packages/dsh-memory-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory-ui",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "Settings UI for DSH local long-term memory",
   "type": "module",

--- a/packages/dsh-memory/lib/index.js
+++ b/packages/dsh-memory/lib/index.js
@@ -931,6 +931,7 @@ export class MemoryRepository {
         path: file,
         id: recordId,
         type: metadata?.type ?? null,
+        status: metadata?.status ?? null,
         tags: metadata?.tags ?? [],
         updatedAt: metadata?.updated_at ?? null,
         rawBody: body,
@@ -966,6 +967,7 @@ export class MemoryRepository {
     const { records, warnings: scanWarnings } = await this.scanRecords(root, usage);
     const results = [];
     for (const record of records) {
+      if (!includeArchive && (record.status === "superseded" || record.status === "archived")) continue;
       const score = this.rawLexicalScore(record, tokens);
       if (score <= 0) continue;
       const first = record.__bodyLower.indexOf(tokens[0]);
@@ -997,14 +999,20 @@ export class MemoryRepository {
    * when the index is unavailable.
    */
   async retrieve(root, query, scope, usage, warnings) {
-    const inScope = scope === "archive"
+    // v0.9.1: the default active scope also excludes records whose own
+    // status is superseded or archived (expired records are already skipped
+    // at scan time), so retired knowledge stays retrievable only through an
+    // explicit "all" scope or the archive directory itself.
+    const inPathScope = scope === "archive"
       ? (path) => path.startsWith("archive/")
       : scope === "active"
         ? (path) => !path.startsWith("archive/")
         : () => true;
+    const inRecordScope = (record) =>
+      inPathScope(record.path) && (scope !== "active" || (record.status !== "superseded" && record.status !== "archived"));
     const { records, warnings: scanWarnings } = await this.scanRecords(root, usage);
-    warnings.push(...scanWarnings.filter((warning) => inScope(warning.path)));
-    const candidates = records.filter((record) => inScope(record.path));
+    warnings.push(...scanWarnings.filter((warning) => inPathScope(warning.path)));
+    const candidates = records.filter((record) => inRecordScope(record));
     const tokens = query.toLowerCase().split(/[^\p{L}\p{N}]+/u).filter((token) => token.length > 0);
     if (tokens.length === 0) throw memoryError("search-invalid-request");
     for (const record of candidates) {

--- a/packages/dsh-memory/lib/index.js
+++ b/packages/dsh-memory/lib/index.js
@@ -143,7 +143,7 @@ function startSummaryWatcher(onChange) {
     lastSeen = { mtimeMs: stat.mtimeMs, size: stat.size };
   } catch {}
   let debounceTimer = null;
-  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS }, (current) => {
+  watchFile(summaryPath, { interval: SUMMARY_WATCH_INTERVAL_MS, persistent: false }, (current) => {
     // A zeroed stat means the file is temporarily gone; the snapshot
     // retention in buildMemorySectionText covers it, so do not refresh.
     if (!current || (current.size === 0 && current.mtimeMs === 0)) return;

--- a/packages/dsh-memory/lib/memory-metadata.js
+++ b/packages/dsh-memory/lib/memory-metadata.js
@@ -263,26 +263,40 @@ export function topicKey(metadata) {
 }
 
 /**
- * Deterministic conflict resolution. Given records that share a topicKey,
- * pick the winner in a stable order that never depends on file order:
+ * Explicit-only conflict resolution (v0.9.1). Given records that share a
+ * topicKey, a winner emerges only through explicit declarations — implicit
+ * "newest wins" ordering is gone because it silently discarded knowledge:
  *   1. expired records never win (lazy expiry projection);
- *   2. status precedence active > candidate > conflicted > superseded >
- *      archived;
- *   3. newest updated_at wins;
- *   4. lexicographically smallest id breaks the tie.
- * Returns the winning record, or null when no record is eligible.
+ *   2. records whose own status is superseded or archived are projected out;
+ *   3. a record named in another eligible record's `supersedes` is excluded
+ *      (explicit supersession);
+ *   4. records linked by `conflicts_with` block each other: neither side can
+ *      win until an operator resolves the conflict explicitly;
+ *   5. exactly one contender remains -> that record wins; zero or multiple
+ *      contenders -> null (unresolved, surfaced as a conflict instead of
+ *      being silently resolved by file order or recency).
+ * Returns the winning record, or null when resolution is not explicit.
  */
 export function resolveTopicConflict(records, now = Date.now()) {
-  const eligible = records.filter((record) => !isExpired(record, now));
+  const eligible = records.filter(
+    (record) => !isExpired(record, now) && record.status !== "superseded" && record.status !== "archived",
+  );
   if (eligible.length === 0) return null;
-  const precedence = Object.freeze({ active: 0, candidate: 1, conflicted: 2, superseded: 3, archived: 4 });
-  return [...eligible].sort((left, right) => {
-    const statusDiff = (precedence[left.status ?? "candidate"] ?? 1) - (precedence[right.status ?? "candidate"] ?? 1);
-    if (statusDiff !== 0) return statusDiff;
-    const dateDiff = String(right.updated_at ?? "").localeCompare(String(left.updated_at ?? ""));
-    if (dateDiff !== 0) return dateDiff;
-    return String(left.id).localeCompare(String(right.id));
-  })[0];
+  const byId = new Map(eligible.map((record) => [record.id, record]));
+  const excluded = new Set();
+  const linkedIds = (record, field) =>
+    [record[field]].filter((id) => typeof id === "string" && id.length > 0 && byId.has(id));
+  for (const record of eligible) {
+    for (const id of linkedIds(record, "supersedes")) excluded.add(id);
+  }
+  for (const record of eligible) {
+    for (const id of linkedIds(record, "conflicts_with")) {
+      excluded.add(record.id);
+      excluded.add(id);
+    }
+  }
+  const contenders = eligible.filter((record) => !excluded.has(record.id));
+  return contenders.length === 1 ? contenders[0] : null;
 }
 
 export const AUDIT_INVALID_METADATA_LIMIT = 20;

--- a/packages/dsh-memory/lib/sync-apply.py
+++ b/packages/dsh-memory/lib/sync-apply.py
@@ -555,9 +555,9 @@ def parse_metadata_scalar(value):
 
 def parse_record_metadata(text, relative):
     if relative == "summary.md" or not relative.endswith(".md") or not path_is_payload(relative):
-        return None
+        return None, None
     if not (text.startswith("---\n") or text.startswith("---\r\n")):
-        return None
+        return None, None
     match = re.match(r"^---\r?\n([\s\S]*?)\r?\n---\r?\n?", text)
     if match is None:
         raise SyncError("invalid-metadata")
@@ -617,7 +617,7 @@ def parse_record_metadata(text, relative):
             not isinstance(values[field], str) or not DATE_RE.fullmatch(values[field])
         ):
             raise SyncError("invalid-metadata")
-    return record_id
+    return record_id, values
 
 
 def metadata_topic_key(record):
@@ -643,21 +643,39 @@ def is_record_expired(record, now=None):
 
 
 def resolve_topic_conflict(records, now=None):
-    """Deterministic winner among records sharing a topic key. Expired records
-    never win; status precedence active > candidate > conflicted > superseded >
-    archived; newest updated_at wins; smallest id breaks ties."""
-    precedence = {"active": 0, "candidate": 1, "conflicted": 2, "superseded": 3, "archived": 4}
-    eligible = [record for record in records if not is_record_expired(record, now)]
+    """Explicit-only conflict resolution (v0.9.1). A winner emerges only
+    through explicit declarations; implicit "newest wins" ordering is gone:
+      1. expired records never win (lazy expiry projection);
+      2. records whose own status is superseded or archived project out;
+      3. a record named in another eligible record's supersedes is excluded;
+      4. records linked by conflicts_with block each other;
+      5. exactly one contender remains -> winner; otherwise None."""
+    eligible = [
+        record for record in records
+        if not is_record_expired(record, now) and record.get("status") not in ("superseded", "archived")
+    ]
     if not eligible:
         return None
-    return sorted(
-        eligible,
-        key=lambda record: (
-            precedence.get(record.get("status") or "candidate", 1),
-            -(record.get("updated_at") or ""),
-            record.get("id") or "",
-        ),
-    )[0]
+    by_id = {record.get("id"): record for record in eligible if isinstance(record.get("id"), str)}
+    excluded = set()
+
+    def linked(record, field):
+        value = record.get(field)
+        if isinstance(value, str) and value and value in by_id and by_id[value] is not record:
+            return value
+        return None
+
+    for record in eligible:
+        target = linked(record, "supersedes")
+        if target is not None:
+            excluded.add(target)
+    for record in eligible:
+        target = linked(record, "conflicts_with")
+        if target is not None:
+            excluded.add(record.get("id"))
+            excluded.add(target)
+    contenders = [record for record in eligible if record.get("id") not in excluded]
+    return contenders[0] if len(contenders) == 1 else None
 
 
 def duplicate_error(record_id, first_path, second_path, phase, run_id=None):
@@ -691,7 +709,7 @@ def scan_duplicate_ids(directory_fd, file_iterator, phase, run_id=None):
             text = content.decode("utf-8")
         except UnicodeDecodeError:
             continue
-        record_id = parse_record_metadata(text, relative)
+        record_id, _values = parse_record_metadata(text, relative)
         if record_id is not None:
             if record_id in ids:
                 raise duplicate_error(record_id, ids[record_id], relative, phase, run_id)
@@ -702,6 +720,7 @@ def validate_staging_limits(staging_fd, manifest, phase="staging-diff", run_id=N
     baseline = {entry["path"]: entry for entry in manifest.get("entries", [])}
     observed = {}
     ids = {}
+    meta_by_path = {}
     for relative, entry_stat in walk_staging_tree(staging_fd):
         if entry_stat.st_size > MAX_FILE_BYTES:
             raise SyncError("file-too-large")
@@ -725,15 +744,32 @@ def validate_staging_limits(staging_fd, manifest, phase="staging-diff", run_id=N
             raise SyncError("binary-file")
         if relative == "summary.md" and len(content) > SUMMARY_BUDGET_BYTES:
             raise SyncError("summary-too-large")
-        record_id = parse_record_metadata(text, relative)
+        record_id, values = parse_record_metadata(text, relative)
         if record_id is not None:
             if record_id in ids:
                 raise duplicate_error(record_id, ids[record_id], relative, phase, run_id)
             ids[record_id] = relative
         observed[relative] = {"size": len(content), "sha256": hashlib.sha256(content).hexdigest()}
+        if record_id is not None:
+            meta_by_path[relative] = values
     added = [path for path in observed if path not in baseline and path_is_payload(path)]
     modified = [path for path in observed if path in baseline and baseline[path].get("sha256") != observed[path]["sha256"] and path_is_payload(path)]
     deleted = [path for path in baseline if path not in observed and path_is_payload(path)]
+    # v0.9.1: newly added handbook records must carry provenance — at least
+    # one of source_rollouts, source_session_digest, or source_hash. Existing
+    # (baseline) handbook records are exempt so legacy migration keeps
+    # working; the model's new consolidated knowledge must stay traceable.
+    for path in added:
+        if not path.startswith("handbook/") or not path.endswith(".md"):
+            continue
+        values = meta_by_path.get(path)
+        has_provenance = values is not None and (
+            bool(values.get("source_rollouts"))
+            or (isinstance(values.get("source_session_digest"), str) and bool(values["source_session_digest"]))
+            or (isinstance(values.get("source_hash"), str) and bool(values["source_hash"]))
+        )
+        if not has_provenance:
+            raise SyncError("missing-provenance", {"path": path, "phase": phase, "run_id": run_id} if run_id is not None else {"path": path, "phase": phase})
     if len(added) > MAX_ADDED_FILES:
         raise SyncError("too-many-files")
     changed_bytes = sum(observed[path]["size"] for path in added + modified)

--- a/packages/dsh-memory/package.json
+++ b/packages/dsh-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "Automatic local long-term memory for DSH",
   "type": "module",

--- a/packages/dsh-memory/templates/README.md
+++ b/packages/dsh-memory/templates/README.md
@@ -62,4 +62,6 @@ source_rollouts:
 
 提炼时只保留：稳定用户偏好、最终方案与原因、失败模式、项目入口、可复现命令和明确的后续契约。无高信号时写 `NO_SIGNAL` 并跳过。
 
+溯源与显式冲突链（宿主 fail-closed 校验）：新增 `handbook/` 条目必须至少携带 `source_rollouts`、`source_session_digest`、`source_hash` 之一，否则宿主拒绝整个 staging diff（`missing-provenance`）。覆盖旧条目时不要静默改写：新条目声明 `supersedes: <旧条目 id>`，并把旧条目 `status` 置为 `superseded`（或移入 `archive/`）；确有无法合并的矛盾时用 `conflicts_with: <对方 id>` 显式标注，等待人工裁决。
+
 整合时先比较新旧条目：冲突则覆盖、过时则移入 `archive/`、无变化则不制造噪声。`summary.md` 最终必须不超过 12 KiB；超出时压缩重复过程和细节，不得静默超出预算。不要执行 git、不要更新同步水位：宿主会在 staging 校验通过后代为提交。

--- a/tests/helpers/dsh-e2e-service.mjs
+++ b/tests/helpers/dsh-e2e-service.mjs
@@ -74,6 +74,7 @@ async function seedPendingPreview(root, index = 2) {
     `id: e2e/preview-${index}`,
     "type: fact",
     "status: active",
+    `source_session_digest: e2e-preview-${index}`,
     "created_at: 2026-08-21",
     "updated_at: 2026-08-21",
     "---",

--- a/tests/test_dsh_memory_marketplace.mjs
+++ b/tests/test_dsh_memory_marketplace.mjs
@@ -11,7 +11,7 @@ const manifest = JSON.parse(await readFile(join(project, "package.json"), "utf8"
 const patch = await readFile(join(project, "packages/dsh-git-memory/cordis.patch.yml"), "utf8");
 
 assert.equal(manifest.name, "dsh-git-memory");
-assert.equal(manifest.version, "0.9.0");
+assert.equal(manifest.version, "0.9.1");
 assert.notEqual(manifest.private, true);
 assert.equal(manifest.main, "./packages/dsh-git-memory/lib/index.js");
 assert.equal(manifest.exports["."], "./packages/dsh-git-memory/lib/index.js");

--- a/tests/test_dsh_memory_metadata.mjs
+++ b/tests/test_dsh_memory_metadata.mjs
@@ -151,25 +151,53 @@ body`, "handbook/project.md");
   assert.equal(topicKey({ id: "project/codegen", type: "decision" }), "decision:project");
   assert.equal(topicKey({ id: "plain", type: "preference" }), "preference:");
   assert.equal(topicKey({ id: "a/b", type: "fact" }), "fact:a");
-  // Conflict resolution: active beats candidate, newest updated_at wins,
-  // expired records never win, smallest id breaks ties.
-  const candidates = [
-    { id: "ns/topic", type: "fact", status: "candidate", updated_at: "2026-08-05" },
-    { id: "ns/topic", type: "fact", status: "active", updated_at: "2026-08-01" },
-    { id: "ns/topic", type: "fact", status: "active", updated_at: "2026-08-03", expires_at: "2020-01-01" },
-    { id: "ns/topic", type: "fact", status: "active", updated_at: "2026-08-03" },
+  // v0.9.1: explicit-only conflict resolution. A winner emerges only through
+  // an explicit supersedes link; implicit newest-wins ordering is gone.
+  const linked = [
+    { id: "ns/old", type: "fact", status: "active", updated_at: "2026-08-09" },
+    { id: "ns/new", type: "fact", status: "active", updated_at: "2026-08-01", supersedes: "ns/old" },
   ];
-  const winner = resolveTopicConflict(candidates);
-  assert.equal(winner.status, "active");
-  assert.equal(winner.updated_at, "2026-08-03");
-  assert.equal(winner.expires_at, undefined);
-  // All expired -> no winner.
-  const stale = candidates.map((record) => ({ ...record, expires_at: "2020-01-01" }));
+  assert.equal(resolveTopicConflict(linked).id, "ns/new");
+  // No explicit link -> unresolved, regardless of recency or status.
+  const unlinked = [
+    { id: "ns/a", type: "fact", status: "active", updated_at: "2026-08-05" },
+    { id: "ns/b", type: "fact", status: "candidate", updated_at: "2026-08-01" },
+  ];
+  assert.equal(resolveTopicConflict(unlinked), null);
+  // A conflicts_with link blocks both sides until an operator resolves it.
+  const conflicting = [
+    { id: "ns/a", type: "fact", supersedes: "ns/old" },
+    { id: "ns/b", type: "fact", conflicts_with: "ns/a" },
+    { id: "ns/old", type: "fact" },
+  ];
+  assert.equal(resolveTopicConflict(conflicting), null);
+  // Own status superseded/archived projects out; expired records never win;
+  // a single remaining contender wins without any link.
+  const projected = [
+    { id: "ns/a", type: "fact", status: "archived" },
+    { id: "ns/b", type: "fact", status: "superseded" },
+    { id: "ns/c", type: "fact", expires_at: "2020-01-01" },
+    { id: "ns/d", type: "fact" },
+  ];
+  assert.equal(resolveTopicConflict(projected).id, "ns/d");
+  const stale = projected.map((record) => ({ ...record, expires_at: "2020-01-01" }));
   assert.equal(resolveTopicConflict(stale), null);
   // isExpired projection.
   assert.equal(isExpired({ expires_at: "2020-01-01" }), true);
   assert.equal(isExpired({ expires_at: "2999-01-01" }), false);
   assert.equal(isExpired({}), false);
+}
+
+{
+  // v0.9.1: legacy migration front matter is the minimum valid schema set —
+  // no inferred type/status/confidence — and parses as a structured record.
+  const { migrationFrontMatter } = await import("../packages/dsh-memory/lib/legacy-migration.js");
+  const frontMatter = migrationFrontMatter("handbook/old-note.md", new Date("2026-01-02T03:04:05Z"));
+  assert.match(frontMatter, /^---\nschema_version: 1\nid: legacy-[0-9a-f]{16}\ncreated_at: 2026-01-02\nupdated_at: 2026-01-02\n---\n/);
+  const migrated = parseFrontMatter(`${frontMatter}old note body\n`, "handbook/old-note.md");
+  assert.equal(migrated.id.startsWith("legacy-"), true);
+  assert.equal(migrated.type, "observation");
+  assert.equal(migrated.status, "active");
 }
 
 {

--- a/tests/test_dsh_memory_preview.mjs
+++ b/tests/test_dsh_memory_preview.mjs
@@ -31,7 +31,10 @@ async function seedPreview(root, previewId, changedPath, content, createdAt = "2
   await execFile("/usr/bin/python3", [helper, "prepare-preview", "--root", root, "--run-id", previewId]);
   const previewRoot = join(root, ".sync", "previews", previewId);
   await mkdir(join(previewRoot, "staging", "handbook"), { recursive: true });
-  await writeFile(join(previewRoot, "staging", changedPath), content);
+  // v0.9.1: staged handbook records must carry provenance — seed records in
+  // the same shape the model is required to produce.
+  const record = `---\nschema_version: 1\nid: preview-${previewId.slice(-8)}\ntype: observation\nsource_session_digest: seed-${previewId}\n---\n`;
+  await writeFile(join(previewRoot, "staging", changedPath), record + content);
   await writeFile(join(previewRoot, "preview.json"), JSON.stringify({
     preview_id: previewId,
     created_at: createdAt,
@@ -66,7 +69,7 @@ async function seedPreview(root, previewId, changedPath, content, createdAt = "2
   assert.equal(applied.ok, true, JSON.stringify(applied));
   assert.equal(applied.value.status, "applied");
   assert.deepEqual(applied.value.changed_paths, ["handbook/api.md"]);
-  assert.equal(await readFile(join(root, "handbook", "api.md"), "utf8"), "api preview\n");
+  assert.equal((await readFile(join(root, "handbook", "api.md"), "utf8")).endsWith("api preview\n"), true);
   // The preview is consumed.
   const after = await service.previews();
   assert.equal(after.value.previews.length, 0);

--- a/tests/test_dsh_memory_retrieval_eval.mjs
+++ b/tests/test_dsh_memory_retrieval_eval.mjs
@@ -259,6 +259,27 @@ if (rebuilt.value.retrieval.mode === "hybrid") {
   assert.equal(rebuilt.value.results[0].path, "handbook/retrieval-extra.md");
 }
 
+// v0.9.1: the default (active) scope excludes status-superseded records;
+// they remain retrievable through an explicit "all" scope.
+await writeFile(join(root, "handbook", "superseded-note.md"), `---
+schema_version: 1
+id: infra/superseded-note
+type: observation
+status: superseded
+---
+superseded zzz-exclusive caching guidance that must not surface by default.
+`);
+await git(root, ["add", "."]);
+await git(root, ["commit", "-m", "add superseded fixture"]);
+{
+  const active = await service.search({ query: "zzz-exclusive" });
+  assert.equal(active.ok, true);
+  assert.equal(active.value.results.some((entry) => entry.path === "handbook/superseded-note.md"), false);
+  const all = await service.search({ query: "zzz-exclusive", scope: "all" });
+  assert.equal(all.ok, true);
+  assert.ok(all.value.results.some((entry) => entry.path === "handbook/superseded-note.md"));
+}
+
 // Degraded mode: a corrupt index plus an unwritable .sync directory forces
 // the pure-scan fallback with correct results.
 // Corrupt the SQLite header (not the tail: SQLite tolerates trailing junk

--- a/tests/test_dsh_memory_sync_batch.sh
+++ b/tests/test_dsh_memory_sync_batch.sh
@@ -21,7 +21,7 @@ done
 cat > "$TEST_BIN/dsh" <<'EOF'
 #!/bin/zsh
 set -euo pipefail
-print -- 'batch synthetic memory' > handbook/batch.md
+print -- "---\nschema_version: 1\nid: batch-entry\ntype: observation\nsource_session_digest: stub-digest\n---\nbatch synthetic memory" > handbook/batch.md
 EOF
 chmod +x "$TEST_BIN/dsh"
 

--- a/tests/test_dsh_memory_sync_chunks.sh
+++ b/tests/test_dsh_memory_sync_chunks.sh
@@ -96,7 +96,7 @@ if [[ -n "\$manifest" && -f "\$manifest" ]]; then
 fi
 print -- "\$n" > "\$out/chunk-count.txt"
 mkdir -p handbook
-print -- "stub consolidation run \$seq" > handbook/consolidated.md
+print -- "---\\nschema_version: 1\\nid: consolidated\\ntype: observation\\nsource_session_digest: stub-digest-\$seq\\n---\\nstub consolidation run \$seq" > handbook/consolidated.md
 EOF
   chmod +x "$bin/dsh"
 }

--- a/tests/test_dsh_memory_sync_env.sh
+++ b/tests/test_dsh_memory_sync_env.sh
@@ -59,7 +59,17 @@ mkdir -p "$PRIVATE_SESSION_ROOT"
 print -r -- "$PRIVATE_SESSION_ROOT" > "$HOME/private-session-root.txt"
 [[ "${DSH_PERMISSION_MODE:-}" == "workspace-write" ]]
 # Simulate a model edit inside the staging worktree (the sync cds into staging).
-printf 'synthetic memory entry\n' > handbook/synthetic-entry.md
+# v0.9.1: added handbook records must carry provenance or the host rejects
+# the whole diff with missing-provenance.
+cat > handbook/synthetic-entry.md <<'RECORD'
+---
+schema_version: 1
+id: synthetic-entry
+type: observation
+source_session_digest: synthetic-digest
+---
+synthetic memory entry
+RECORD
 /usr/bin/env | /usr/bin/sed 's/=.*//' | /usr/bin/sort
 EOF
 chmod +x "$TEST_BIN/fake-dsh"
@@ -129,7 +139,7 @@ NODE_SHEBANG_DSH="$TEST_BIN/node-shebang-dsh"
 cat > "$NODE_SHEBANG_DSH" <<'EOF'
 #!/usr/bin/env node
 const fs = require("node:fs");
-fs.writeFileSync("handbook/node-launchd-entry.md", "synthetic node launchd entry\n");
+fs.writeFileSync("handbook/node-launchd-entry.md", "---\nschema_version: 1\nid: node-launchd-entry\ntype: observation\nsource_session_digest: synthetic-digest\n---\nsynthetic node launchd entry\n");
 EOF
 chmod +x "$NODE_SHEBANG_DSH"
 touch -t 200001010000 "$TEST_MEMORY_ROOT/.last-sync"

--- a/tests/test_dsh_memory_sync_failures.py
+++ b/tests/test_dsh_memory_sync_failures.py
@@ -141,10 +141,48 @@ def test_summary_budget_fails_closed():
         assert result["error"]["code"] == "summary-too-large", result
 
 
+def test_missing_provenance():
+    # v0.9.1: a newly added handbook record without provenance fails closed;
+    # the same record with source_rollouts (or digest/hash) applies cleanly,
+    # and modifications to baseline records stay exempt.
+    with tempfile.TemporaryDirectory(prefix="dsh-memory-provenance-") as directory:
+        root = pathlib.Path(directory) / "memory"
+        root.mkdir()
+        init_root(root)
+        staging = pathlib.Path(directory) / "staging"
+        manifest = pathlib.Path(directory) / "manifest.json"
+        code, result = run_helper("stage-copy", "--root", root, "--staging", staging, "--manifest", manifest)
+        assert code == 0, result
+        (staging / "handbook/new.md").write_text(
+            "---\nschema_version: 1\nid: hand/new\ntype: decision\n---\nbody\n", encoding="utf-8")
+        code, result = run_helper("diff", "--staging", staging, "--manifest", manifest)
+        assert code != 0, result
+        assert result["error"]["code"] == "missing-provenance", result
+        assert result["error"]["path"] == "handbook/new.md", result
+        # With provenance the same record passes.
+        (staging / "handbook/new.md").write_text(
+            "---\nschema_version: 1\nid: hand/new\ntype: decision\nsource_rollouts:\n  - rollouts/a.md\n---\nbody\n",
+            encoding="utf-8")
+        code, result = run_helper("diff", "--staging", staging, "--manifest", manifest)
+        assert code == 0, result
+        # session-digest provenance also satisfies the gate.
+        (staging / "handbook/new2.md").write_text(
+            "---\nschema_version: 1\nid: hand/new2\ntype: decision\nsource_session_digest: abc123\n---\nbody\n",
+            encoding="utf-8")
+        code, result = run_helper("diff", "--staging", staging, "--manifest", manifest)
+        assert code == 0, result
+        # Modifying a baseline handbook record stays exempt from the gate.
+        (staging / "handbook/a.md").write_text(
+            "---\nschema_version: 1\nid: same-record\ntype: fact\n---\nedited body\n", encoding="utf-8")
+        code, result = run_helper("diff", "--staging", staging, "--manifest", manifest)
+        assert code == 0, result
+
+
 if __name__ == "__main__":
     test_baseline_duplicate()
     test_staging_duplicate()
     test_failure_state_semantics()
     test_readonly_reference_is_not_payload()
     test_summary_budget_fails_closed()
+    test_missing_provenance()
     print("dsh-memory sync failure diagnostics tests passed")

--- a/tests/test_dsh_memory_sync_lock.sh
+++ b/tests/test_dsh_memory_sync_lock.sh
@@ -51,7 +51,7 @@ touch -t 200001010001 "$TEST_DSH_HOME/sessions/session.jsonl.zstd"
 cat > "$TEST_BIN/dsh" <<'EOF'
 #!/bin/zsh
 set -euo pipefail
-printf 'synthetic memory entry\n' > handbook/synthetic.md
+printf -- "---\nschema_version: 1\nid: synthetic-entry\ntype: observation\nsource_session_digest: stub-digest\n---\nsynthetic memory entry\n" > handbook/synthetic.md
 exit 0
 EOF
 chmod +x "$TEST_BIN/dsh"

--- a/tests/test_dsh_memory_sync_preview.sh
+++ b/tests/test_dsh_memory_sync_preview.sh
@@ -47,7 +47,7 @@ touch -t 200001010001 "$TEST_DSH_HOME/sessions/session.jsonl.zstd"
 cat > "$TEST_BIN/dsh" <<'EOF'
 #!/bin/zsh
 set -euo pipefail
-printf 'preview entry %s\n' "$(date +%s)" > handbook/preview-cli.md
+printf -- '---\nschema_version: 1\nid: preview-cli\ntype: observation\nsource_session_digest: stub-digest\n---\npreview entry %s\n' "$(date +%s)" > handbook/preview-cli.md
 exit 0
 EOF
 chmod +x "$TEST_BIN/dsh"
@@ -78,6 +78,9 @@ meta = json.load(open(sys.argv[1]))
 assert meta["preview_id"].endswith("a1b2c3d4"), meta
 assert meta["status"] == "pending", meta
 assert "handbook/preview-cli.md" in meta["changed_paths"], meta
+# v0.9.1: enrichment (handbook/) is an independent preview category.
+assert meta["enrichment_paths"] == ["handbook/preview-cli.md"], meta
+assert meta["consolidation_paths"] == [], meta
 assert meta["expires_at"] > meta["created_at"], meta
 PY
 

--- a/tools/public-tree-check.mjs
+++ b/tools/public-tree-check.mjs
@@ -246,9 +246,9 @@ try {
     }
 
     const expectedManifestVersions = {
-      "package.json": "0.9.0",
-      "packages/dsh-memory/package.json": "0.9.0",
-      "packages/dsh-memory-ui/package.json": "0.9.0",
+      "package.json": "0.9.1",
+      "packages/dsh-memory/package.json": "0.9.1",
+      "packages/dsh-memory-ui/package.json": "0.9.1",
     };
     for (const manifestPath of Object.keys(expectedManifestVersions)) {
       const content = readSnapshotText(snapshot, manifestPath);


### PR DESCRIPTION
## Summary

Stacked on #31 (`feat/v0.9.0-hybrid-retrieval`).

- **Explicit-only conflict resolution**: `resolveTopicConflict()` (JS + staging helper) resolves only through an explicit `supersedes` link; `conflicts_with` links block both sides; implicit "newest wins" ordering removed. Expired and status `superseded`/`archived` records still project out.
- **Handbook provenance gate (fail-closed)**: newly added `handbook/` records in a staged diff require `source_rollouts` / `source_session_digest` / `source_hash` (error `missing-provenance`); baseline records exempt so legacy migration is unaffected. Consolidation prompt and managed template README updated to teach the contract.
- **Independent enrichment preview**: preview metadata now carries `enrichment_paths` (handbook/) and `consolidation_paths`; run output reports both categories. Staging-diff failures print structured details (path/phase/run id).
- **Default retrieval scope** excludes status `superseded`/`archived` records; reachable via `scope: "all"` and the archive directory.
- **Release checklist** gains the local deployment acceptance sequence (backup → quiesce LaunchAgent only → safe-window restart → zero-Provider `--scan-only --json` acceptance → reload → retrieval smoke).
- `SYNC_POLICY_VERSION` → `v0.9.1` (staging contract changed).

## Test plan

- [x] `test_dsh_memory_metadata.mjs` — explicit-link conflict semantics + minimal migration front matter
- [x] `test_dsh_memory_sync_failures.py` — new `missing-provenance` staging-diff case (reject/provenance variants/digest-only/baseline exempt)
- [x] `test_dsh_memory_retrieval_eval.mjs` — superseded-record scope exclusion (active vs all)
- [x] `test_dsh_memory_sync_preview.sh` — enrichment_paths/consolidation_paths in preview.json
- [x] Full regression small-batch green (env: `no_change` sandbox limitation and `tools.mjs` post-pass hang reproduce on the 0.8.4 baseline; not regressions)
- [x] public-tree, release guards, secret scan, marketplace bundle (11 files)