### PR TITLE
fix: keep hyphenated searches on the FTS path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-09-01
+
+### Fixed
+
+- Quote FTS5 search terms before constructing `MATCH` expressions so
+  hyphenated identifiers (for example, `pending-candidates`) stay on the
+  hybrid index path instead of being parsed as SQLite expressions.
+- Add a regression case to the retrieval evaluation for hyphenated queries.
+
+### Distribution
+
+- Distributed through GitHub source installs and GitHub Releases; not
+  published to npm.
+
 ## [0.9.1] - 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ not expose the filesystem root or execute Git directly.
 
 ## Compatibility
 
-`v0.9.1` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
+`v0.9.2` keeps the DSH `0.1.0-rc.6` peer-compatibility range and has been
 tested and locally integrated with a consistently pinned `0.1.0-rc.7` graph:
 
 | Component | Supported version |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-git-memory",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-git-memory",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "workspaces": [
         "packages/dsh-memory",
@@ -1143,7 +1143,7 @@
       }
     },
     "packages/dsh-memory": {
-      "version": "0.8.2",
+      "version": "0.9.2",
       "license": "MIT",
       "engines": {
         "node": ">=22"
@@ -1156,7 +1156,7 @@
       }
     },
     "packages/dsh-memory-ui": {
-      "version": "0.8.1",
+      "version": "0.9.2",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-git-memory",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": false,
   "description": "A local Git-backed long-term memory bundle for DeepSeek Harness",
   "type": "module",

--- a/packages/dsh-git-memory/lib/search-index.js
+++ b/packages/dsh-git-memory/lib/search-index.js
@@ -92,7 +92,10 @@ function ftsMatchOr(terms) {
 }
 
 function ftsMatchPlain(terms) {
-  return terms.join(" OR ");
+  // Quote every token before handing it to SQLite's MATCH parser. Bare
+  // hyphenated identifiers (for example, "pending-candidates") are parsed as
+  // expressions and can be reported as an unknown column instead of a term.
+  return terms.map((term) => `"${term.replaceAll('"', '""')}"`).join(" OR ");
 }
 
 async function ensureIndexGitExcludes(root) {

--- a/packages/dsh-memory-ui/package.json
+++ b/packages/dsh-memory-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory-ui",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "description": "Settings UI for DSH local long-term memory",
   "type": "module",

--- a/packages/dsh-memory/lib/search-index.js
+++ b/packages/dsh-memory/lib/search-index.js
@@ -92,7 +92,10 @@ function ftsMatchOr(terms) {
 }
 
 function ftsMatchPlain(terms) {
-  return terms.join(" OR ");
+  // Quote every token before handing it to SQLite's MATCH parser. Bare
+  // hyphenated identifiers (for example, "pending-candidates") are parsed as
+  // expressions and can be reported as an unknown column instead of a term.
+  return terms.map((term) => `"${term.replaceAll('"', '""')}"`).join(" OR ");
 }
 
 async function ensureIndexGitExcludes(root) {

--- a/packages/dsh-memory/package.json
+++ b/packages/dsh-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-memory",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "description": "Automatic local long-term memory for DSH",
   "type": "module",

--- a/tests/test_dsh_memory_marketplace.mjs
+++ b/tests/test_dsh_memory_marketplace.mjs
@@ -11,7 +11,7 @@ const manifest = JSON.parse(await readFile(join(project, "package.json"), "utf8"
 const patch = await readFile(join(project, "packages/dsh-git-memory/cordis.patch.yml"), "utf8");
 
 assert.equal(manifest.name, "dsh-git-memory");
-assert.equal(manifest.version, "0.9.1");
+assert.equal(manifest.version, "0.9.2");
 assert.notEqual(manifest.private, true);
 assert.equal(manifest.main, "./packages/dsh-git-memory/lib/index.js");
 assert.equal(manifest.exports["."], "./packages/dsh-git-memory/lib/index.js");

--- a/tests/test_dsh_memory_retrieval_eval.mjs
+++ b/tests/test_dsh_memory_retrieval_eval.mjs
@@ -236,6 +236,15 @@ if (hybridProbe.value.retrieval.mode === "hybrid") {
   assert.equal(hybridProbe.value.retrieval.stamp, expectedStamp);
 }
 
+// Hyphenated Latin identifiers must remain a valid FTS query. An unquoted
+// token such as "pending-candidates" is parsed by SQLite as an expression
+// (and may be mistaken for a column), which must never downgrade an otherwise
+// healthy derived index to the scan path.
+const hyphenated = await service.search({ query: "pending-candidates", limit: 10 });
+assert.equal(hyphenated.ok, true);
+assert.equal(hyphenated.value.results[0].path, "rollouts/chunked-delivery.md");
+assert.equal(hyphenated.value.retrieval.mode, "hybrid");
+
 // A new commit invalidates the stamp: the next search rebuilds, and the one
 // after that is fresh again.
 await writeFile(join(root, "handbook", "retrieval-extra.md"), `---

--- a/tools/public-tree-check.mjs
+++ b/tools/public-tree-check.mjs
@@ -246,9 +246,9 @@ try {
     }
 
     const expectedManifestVersions = {
-      "package.json": "0.9.1",
-      "packages/dsh-memory/package.json": "0.9.1",
-      "packages/dsh-memory-ui/package.json": "0.9.1",
+      "package.json": "0.9.2",
+      "packages/dsh-memory/package.json": "0.9.2",
+      "packages/dsh-memory-ui/package.json": "0.9.2",
     };
     for (const manifestPath of Object.keys(expectedManifestVersions)) {
       const content = readSnapshotText(snapshot, manifestPath);


### PR DESCRIPTION
## Summary

- Quote FTS5 MATCH terms so hyphenated identifiers such as `pending-candidates` remain on the hybrid retrieval path.
- Add a regression case to the retrieval evaluation and mirror the fix into the public bundle.
- Bump the source-only bundle to `0.9.2` and document GitHub source/Release distribution (no npm publication).

## Validation

- `npm test` (Node 22.22.3): passed
- `git diff --check`: passed
- No provider/model requests are made by this change.

## Known limitation

A single candidate larger than `MAX_CANDIDATE_BYTES` can still reject a batch; skip-and-journal is intentionally deferred to a follow-up issue.
